### PR TITLE
Add computation for net band-by-band fluxes

### DIFF
--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -117,9 +117,11 @@ int main(int argc , char **argv) {
       real2d flux_up ("flux_up" ,ncol,nlay+1);
       real2d flux_dn ("flux_dn" ,ncol,nlay+1);
       real2d flux_dir("flux_dir",ncol,nlay+1);
+      real2d flux_net("flux_net",ncol,nlay+1);
       real3d bnd_flux_up ("bnd_flux_up" ,ncol,nlay+1,nbnd);
       real3d bnd_flux_dn ("bnd_flux_dn" ,ncol,nlay+1,nbnd);
       real3d bnd_flux_dir("bnd_flux_dir",ncol,nlay+1,nbnd);
+      real3d bnd_flux_net("bnd_flux_net",ncol,nlay+1,nbnd);
 
       // Clouds
       real2d lwp("lwp",ncol,nlay);
@@ -157,9 +159,11 @@ int main(int argc , char **argv) {
         fluxes.flux_up     = flux_up ;
         fluxes.flux_dn     = flux_dn ;
         fluxes.flux_dn_dir = flux_dir;
+        fluxes.flux_net    = flux_net;
         fluxes.bnd_flux_up     = bnd_flux_up ;
         fluxes.bnd_flux_dn     = bnd_flux_dn ;
         fluxes.bnd_flux_dn_dir = bnd_flux_dir;
+        fluxes.bnd_flux_net = bnd_flux_net;
 
         k_dist.gas_optics(top_at_1, p_lay, p_lev, t_lay, gas_concs, atmos, toa_flux);
         clouds.delta_scale();
@@ -185,6 +189,7 @@ int main(int argc , char **argv) {
         if (abs(sum(flux_up )-sum(bnd_flux_up ) )/sum(flux_up )        > 1.e-10) exit(-1);
         if (abs(sum(flux_dn )-sum(bnd_flux_dn ) )/sum(flux_dn )        > 1.e-10) exit(-1);
         if (abs(sum(flux_dir)-sum(bnd_flux_dir) )/sum(flux_dir)        > 1.e-10) exit(-1);
+        if (abs(sum(flux_net)-sum(bnd_flux_net) )/sum(flux_net)        > 1.e-10) exit(-1);
       }
 
     } else {  // Longwave
@@ -235,10 +240,12 @@ int main(int argc , char **argv) {
       memset( emis_sfc , 0.98_wp                                   );
 
       // Fluxes
-      real2d flux_up ("flux_up" ,ncol,nlay+1);
-      real2d flux_dn ("flux_dn" ,ncol,nlay+1);
+      real2d flux_up ( "flux_up" ,ncol,nlay+1);
+      real2d flux_dn ( "flux_dn" ,ncol,nlay+1);
+      real2d flux_net("flux_net" ,ncol,nlay+1);
       real3d bnd_flux_up ("bnd_flux_up" ,ncol,nlay+1,nbnd);
       real3d bnd_flux_dn ("bnd_flux_dn" ,ncol,nlay+1,nbnd);
+      real3d bnd_flux_net("bnd_flux_net" ,ncol,nlay+1,nbnd);
 
       // Clouds
       real2d lwp("lwp",ncol,nlay);
@@ -279,8 +286,10 @@ int main(int argc , char **argv) {
         FluxesByband fluxes;
         fluxes.flux_up = flux_up;
         fluxes.flux_dn = flux_dn;
+        fluxes.flux_net= flux_net;
         fluxes.bnd_flux_up = bnd_flux_up;
         fluxes.bnd_flux_dn = bnd_flux_dn;
+        fluxes.bnd_flux_net= bnd_flux_net;
 
         // Calling with an empty col_dry parameter
         k_dist.gas_optics(top_at_1, p_lay, p_lev, t_lay, t_sfc, gas_concs, atmos, lw_sources, real2d(), t_lev);
@@ -304,6 +313,7 @@ int main(int argc , char **argv) {
         // And test to make sure our broadband and byband fluxes are consistent
         if (abs(sum(flux_up )-sum(bnd_flux_up ) )/sum(flux_up )        > 1.e-10) exit(-1);
         if (abs(sum(flux_dn )-sum(bnd_flux_dn ) )/sum(flux_dn )        > 1.e-10) exit(-1);
+        if (abs(sum(flux_net)-sum(bnd_flux_net) )/sum(flux_net)        > 1.e-10) exit(-1);
       }
 
     }  // if (is_sw)

--- a/cpp/extensions/fluxes_byband/mo_fluxes_byband.h
+++ b/cpp/extensions/fluxes_byband/mo_fluxes_byband.h
@@ -32,6 +32,8 @@ class FluxesByband : public FluxesBroadband {
         if (allocated(this->bnd_flux_net)) {
             if (allocated(this->bnd_flux_dn) && allocated(this->bnd_flux_up)) {
                 net_byband(ncol, nlev, nbnd, this->bnd_flux_dn, this->bnd_flux_up, this->bnd_flux_net);
+            } else {
+                stoprun("reduce: bnd_flux_net requested but bnd_flux_dn or bnd_flux_up not allocated.");
             }
         }
     }

--- a/cpp/extensions/fluxes_byband/mo_fluxes_byband.h
+++ b/cpp/extensions/fluxes_byband/mo_fluxes_byband.h
@@ -28,6 +28,12 @@ class FluxesByband : public FluxesBroadband {
         if (allocated(this->bnd_flux_up    )) { sum_byband(ncol, nlev, ngpt, nbnd, band2gpt, gpt_flux_up,     this->bnd_flux_up    ); }
         if (allocated(this->bnd_flux_dn    )) { sum_byband(ncol, nlev, ngpt, nbnd, band2gpt, gpt_flux_dn,     this->bnd_flux_dn    ); }
         if (allocated(this->bnd_flux_dn_dir)) { sum_byband(ncol, nlev, ngpt, nbnd, band2gpt, gpt_flux_dn_dir, this->bnd_flux_dn_dir); }
+        // Compute net fluxes
+        if (allocated(this->bnd_flux_net)) {
+            if (allocated(this->bnd_flux_dn) && allocated(this->bnd_flux_up)) {
+                net_byband(ncol, nlev, nbnd, this->bnd_flux_dn, this->bnd_flux_up, this->bnd_flux_net);
+            }
+        }
     }
     
 };

--- a/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.cpp
+++ b/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.cpp
@@ -10,3 +10,9 @@ void sum_byband(int ncol, int nlev, int ngpt, int nbnd, int2d const &bnd_lims, r
     byband_flux(icol,ilev,ibnd) = bb_flux_s;
   });
 }
+// Compute net flux
+void net_byband(int ncol, int nlev, int nbnd, real3d const &bnd_flux_dn, real3d const &bnd_flux_up, real3d &bnd_flux_net) {
+    parallel_for( Bounds<3>(nbnd,nlev,ncol), YAKL_LAMBDA(int ibnd, int ilev, int icol) {
+        bnd_flux_net(icol,ilev,ibnd) = bnd_flux_dn(icol,ilev,ibnd) - bnd_flux_up(icol,ilev,ibnd);
+    });
+}

--- a/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.h
+++ b/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.h
@@ -1,3 +1,4 @@
 #pragma once
 #include "const.h"
 void sum_byband(int ncol, int nlev, int ngpt, int nbnd, int2d const &bnd_lims, real3d const &spectral_flux, real3d &byband_flux);
+void net_byband(int ncol, int nlev, int nbnd, real3d const &bnd_flux_dn, real3d const &bnd_flux_up, real3d &bnd_flux_net);

--- a/cpp/rte/kernels/mo_fluxes_broadband_kernels.cpp
+++ b/cpp/rte/kernels/mo_fluxes_broadband_kernels.cpp
@@ -1,7 +1,4 @@
-
-
 #include "mo_fluxes_broadband_kernels.h"
-
 
 // Spectral reduction over all points
 void sum_broadband(int ncol, int nlev, int ngpt, real3d const &spectral_flux, real2d &broadband_flux) {
@@ -15,8 +12,6 @@ void sum_broadband(int ncol, int nlev, int ngpt, real3d const &spectral_flux, re
     broadband_flux(icol, ilev) = bb_flux_s;
   });
 }
-
-
 
 // Net flux: Spectral reduction over all points
 void net_broadband(int ncol, int nlev, int ngpt, real3d const &spectral_flux_dn, real3d const &spectral_flux_up, real2d &broadband_flux_net) {
@@ -38,8 +33,6 @@ void net_broadband(int ncol, int nlev, int ngpt, real3d const &spectral_flux_dn,
   std::cout << __FILE__ << ": " << __LINE__ << std::endl;
 }
 
-
-
 // Net flux when bradband flux up and down are already available
 void net_broadband(int ncol, int nlev, real2d const &flux_dn, real2d const &flux_up, real2d &broadband_flux_net) {
   // do ilev = 1, nlev
@@ -50,5 +43,3 @@ void net_broadband(int ncol, int nlev, real2d const &flux_dn, real2d const &flux
   std::cout << "WARNING: THIS ISN'T TESTED!\n";
   std::cout << __FILE__ << ": " << __LINE__ << std::endl;
 }
-
-

--- a/cpp/rte/kernels/mo_fluxes_broadband_kernels.cpp
+++ b/cpp/rte/kernels/mo_fluxes_broadband_kernels.cpp
@@ -29,8 +29,10 @@ void net_broadband(int ncol, int nlev, int ngpt, real3d const &spectral_flux_dn,
     real diff = spectral_flux_dn(icol, ilev, igpt) - spectral_flux_up(icol, ilev, igpt);
     yakl::atomicAdd( broadband_flux_net(icol,ilev) , diff );
   });
+#ifdef RRTMGP_DEBUG
   std::cout << "WARNING: THIS ISN'T TESTED!\n";
   std::cout << __FILE__ << ": " << __LINE__ << std::endl;
+#endif
 }
 
 // Net flux when bradband flux up and down are already available
@@ -40,6 +42,8 @@ void net_broadband(int ncol, int nlev, real2d const &flux_dn, real2d const &flux
   parallel_for( Bounds<2>(nlev,ncol) , YAKL_LAMBDA (int ilev, int icol) {
      broadband_flux_net(icol,ilev) = flux_dn(icol,ilev) - flux_up(icol,ilev);
   });
+#ifdef RRTMGP_DEBUG
   std::cout << "WARNING: THIS ISN'T TESTED!\n";
   std::cout << __FILE__ << ": " << __LINE__ << std::endl;
+#endif
 }


### PR DESCRIPTION
Add missing computation for net band-by-band fluxes. A previous PR added
the FluxesByband class to keep track of spectral fluxes, but we
neglected to properly set the resulting net fluxes (only the up and
down). This also adds a test to the allsky test code to make sure that
the sum of the computed byband fluxes matches the sum of the broadband
fluxes as a sanity check.

[BFB]