### PR TITLE
Transpose dimensions in sfc_alb_dir and sfc_alb_dif

### DIFF
--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -105,8 +105,8 @@ int main(int argc , char **argv) {
 
       //  Boundary conditions depending on whether the k-distribution being supplied
       real2d toa_flux   ("toa_flux"   ,ncol,ngpt);
-      real2d sfc_alb_dir("sfc_alb_dir",nbnd,ncol);
-      real2d sfc_alb_dif("sfc_alb_dif",nbnd,ncol);
+      real2d sfc_alb_dir("sfc_alb_dir",ncol,nbnd);
+      real2d sfc_alb_dif("sfc_alb_dif",ncol,nbnd);
       real1d mu0        ("mu0"        ,ncol);
       // Ocean-ish values for no particular reason
       memset( sfc_alb_dir , 0.06_wp );

--- a/cpp/rte/expand_and_transpose.cpp
+++ b/cpp/rte/expand_and_transpose.cpp
@@ -16,6 +16,7 @@ void expand_and_transpose(OpticalProps const &ops, real2d const &arr_in, real2d 
   });
 }
 
+// Expand from band to g-point dimension, do NOT transpose dimensions
 void expand(OpticalProps const &ops, real2d const &arr_in, real2d &arr_out) {
     int ncol  = size(arr_in, 1);
     int nband = ops.get_nband();

--- a/cpp/rte/expand_and_transpose.cpp
+++ b/cpp/rte/expand_and_transpose.cpp
@@ -16,4 +16,14 @@ void expand_and_transpose(OpticalProps const &ops, real2d const &arr_in, real2d 
   });
 }
 
-
+void expand(OpticalProps const &ops, real2d const &arr_in, real2d &arr_out) {
+    int ncol  = size(arr_in, 1);
+    int nband = ops.get_nband();
+    int ngpt  = ops.get_ngpt();
+    int2d limits = ops.get_band_lims_gpoint();
+    parallel_for(Bounds<2>(nband,ncol), YAKL_LAMBDA (int iband, int icol) {
+        for (int igpt=limits(1,iband); igpt <= limits(2,iband); igpt++) {
+            arr_out(icol,igpt) = arr_in(icol,iband);
+        }
+    });
+}

--- a/cpp/rte/expand_and_transpose.h
+++ b/cpp/rte/expand_and_transpose.h
@@ -6,5 +6,7 @@
 
 // Expand from band to g-point dimension, transpose dimensions (nband, ncol) -> (ncol,ngpt)
 void expand_and_transpose(OpticalProps const &ops, real2d const &arr_in, real2d &arr_out);
+// Expand from band to g-point dimension, do NOT transpose dimensions
+void expand(OpticalProps const &ops, real2d const &arr_in, real2d &arr_out);
 
 

--- a/cpp/rte/mo_rte_sw.h
+++ b/cpp/rte/mo_rte_sw.h
@@ -73,11 +73,11 @@ void rte_sw(OpticalProps2str const &atmos, bool top_at_1, real1d const &mu0, rea
     #endif
   }
 
-  if (size(sfc_alb_dir,1) != nband || size(sfc_alb_dir,2) != ncol) { stoprun("rte_sw: sfc_alb_dir inconsistently sized"); }
+  if (size(sfc_alb_dir,2) != nband || size(sfc_alb_dir,1) != ncol) { stoprun("rte_sw: sfc_alb_dir inconsistently sized"); }
   #ifdef RRTMGP_EXPENSIVE_CHECKS
     if (anyLT(sfc_alb_dir,0._wp) || anyGT(sfc_alb_dir,1._wp)) { stoprun("rte_sw: sfc_alb_dir out of bounds [0,1]"); }
   #endif
-  if (size(sfc_alb_dif,1) != nband || size(sfc_alb_dif,2) != ncol) { stoprun("rte_sw: sfc_alb_dif inconsistently sized"); }
+  if (size(sfc_alb_dif,2) != nband || size(sfc_alb_dif,1) != ncol) { stoprun("rte_sw: sfc_alb_dif inconsistently sized"); }
   #ifdef RRTMGP_EXPENSIVE_CHECKS
     if (anyLT(sfc_alb_dif,0._wp) || anyGT(sfc_alb_dif,1._wp)) { stoprun("rte_sw: sfc_alb_dif out of bounds [0,1]"); }
   #endif
@@ -89,8 +89,8 @@ void rte_sw(OpticalProps2str const &atmos, bool top_at_1, real1d const &mu0, rea
   sfc_alb_dif_gpt = real2d("sfc_alb_dif_gpt",ncol, ngpt);
   // Lower boundary condition -- expand surface albedos by band to gpoints
   //   and switch dimension ordering
-  expand_and_transpose(atmos, sfc_alb_dir, sfc_alb_dir_gpt);
-  expand_and_transpose(atmos, sfc_alb_dif, sfc_alb_dif_gpt);
+  expand(atmos, sfc_alb_dir, sfc_alb_dir_gpt);
+  expand(atmos, sfc_alb_dif, sfc_alb_dif_gpt);
 
   // Compute the radiative transfer...
   // Apply boundary conditions

--- a/cpp/rte/mo_rte_sw.h
+++ b/cpp/rte/mo_rte_sw.h
@@ -88,7 +88,6 @@ void rte_sw(OpticalProps2str const &atmos, bool top_at_1, real1d const &mu0, rea
   sfc_alb_dir_gpt = real2d("sfc_alb_dir_gpt",ncol, ngpt);
   sfc_alb_dif_gpt = real2d("sfc_alb_dif_gpt",ncol, ngpt);
   // Lower boundary condition -- expand surface albedos by band to gpoints
-  //   and switch dimension ordering
   expand(atmos, sfc_alb_dir, sfc_alb_dir_gpt);
   expand(atmos, sfc_alb_dif, sfc_alb_dif_gpt);
 


### PR DESCRIPTION
Transpose dimensions in sfc_alb_dir and sfc_alb_dif to be consistent
with the dimension ordering with the rest of the variables. Previously,
these had dimension (nband,ncol), while everything internal to the code
has dimension order (ncol,ngpt). In fact, in rte_sw, there was a call to
expand_and_transpose to take these inputs with dimension (nband,ncol)
and transpose them to (ncol,ngpt) while also expanding from bands to
gpts. I think this was because it was assumed that models would carry
around albedo with dimension nband,ncol. This is not the case for
SCREAM, nor for E3SM, so making this assumption just means we have an
extra transpose operation. While this was done along with expanding
bands to gpoints, so cost was probably minimal, it is an unneccesary
complication to assume a different dimension order for one field, so
instead we require the user to pass these fields with a dimension
ordering consistent with the rest of the code.