### PR TITLE
Make ncol/nlay inputs at various places

### DIFF
--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -152,7 +152,7 @@ int main(int argc , char **argv) {
         yakl::fence();
         start_time = std::chrono::high_resolution_clock::now();
 
-        cloud_optics.cloud_optics(lwp, iwp, rel, rei, clouds);
+        cloud_optics.cloud_optics(ncol, nlay, lwp, iwp, rel, rei, clouds);
 
         // Solvers
         FluxesByband fluxes;
@@ -165,7 +165,7 @@ int main(int argc , char **argv) {
         fluxes.bnd_flux_dn_dir = bnd_flux_dir;
         fluxes.bnd_flux_net = bnd_flux_net;
 
-        k_dist.gas_optics(top_at_1, p_lay, p_lev, t_lay, gas_concs, atmos, toa_flux);
+        k_dist.gas_optics(ncol, nlay, top_at_1, p_lay, p_lev, t_lay, gas_concs, atmos, toa_flux);
         clouds.delta_scale();
         clouds.increment(atmos);
         rte_sw(atmos, top_at_1, mu0, toa_flux, sfc_alb_dir, sfc_alb_dif, fluxes);

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -250,23 +250,14 @@ public:
   // Derive cloud optical properties from provided cloud physical properties
   // Compute single-scattering properties
   template <class T>  // T is a template for a child class of OpticalPropsArry
-  void cloud_optics(real2d const &clwp, real2d const &ciwp, real2d const &reliq, real2d const &reice, T &optical_props) {
-    int ncol = size(clwp,1);
-    int nlay = size(clwp,2);
+  void cloud_optics(const int ncol, const int nlay, real2d const &clwp, real2d const &ciwp, real2d const &reliq, real2d const &reice, T &optical_props) {
     int nbnd = this->get_nband();
     // Error checking
     if (! (allocated(this->lut_extliq) || allocated(this->pade_extliq))) { stoprun("cloud optics: no data has been initialized"); }
     // Array sizes
-    bool2d liqmsk("liqmsk",size(clwp,1), size(clwp,2));
-    bool2d icemsk("icemsk",size(clwp,1), size(clwp,2));
-    if (size(liqmsk,1) != ncol || size(liqmsk,2) != nlay) { stoprun("cloud optics: liqmask has wrong extents"); }
-    if (size(icemsk,1) != ncol || size(icemsk,2) != nlay) { stoprun("cloud optics: icemsk has wrong extents"); }
-    if (size(ciwp,  1) != ncol || size(ciwp,  2) != nlay) { stoprun("cloud optics: ciwp has wrong extents"); }
-    if (size(reliq, 1) != ncol || size(reliq, 2) != nlay) { stoprun("cloud optics: reliq has wrong extents"); }
-    if (size(reice, 1) != ncol || size(reice, 2) != nlay) { stoprun("cloud optics: reice has wrong extents"); }
-    if (optical_props.get_ncol() != ncol || optical_props.get_nlay() != nlay) {
-      stoprun("cloud optics: optical_props have wrong extents");
-    }
+    bool2d liqmsk("liqmsk",ncol, nlay);
+    bool2d icemsk("icemsk",ncol, nlay);
+
     // Spectral consistency
     if (! this->bands_are_equal(optical_props)) { stoprun("cloud optics: optical properties don't have the same band structure"); }
     if (optical_props.get_nband() != optical_props.get_ngpt() ) {

--- a/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
+++ b/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
@@ -806,19 +806,18 @@ public:
 
   // Compute gas optical depth and Planck source functions, given temperature, pressure, and composition
   template <class T>
-  void gas_optics(bool top_at_1, real2d const &play, real2d const &plev, real2d const &tlay, real1d const &tsfc,
+  void gas_optics(const int ncol, const int nlay,
+                  bool top_at_1, real2d const &play, real2d const &plev, real2d const &tlay, real1d const &tsfc,
                   GasConcs const &gas_desc, T &optical_props, SourceFuncLW &sources,
                   real2d const &col_dry=real2d(), real2d const &tlev=real2d()) {
-    int ncol  = size(play,1);
-    int nlay  = size(play,2);
     int ngpt  = this->get_ngpt();
     int nband = this->get_nband();
     // Interpolation coefficients for use in source function
-    int2d  jtemp ("jtemp"                         ,size(play,1),size(play,2));
-    int2d  jpress("jpress"                        ,size(play,1),size(play,2));
-    bool2d tropo ("tropo"                         ,size(play,1),size(play,2));
-    real6d fmajor("fmajor",2,2,2,this->get_nflav(),size(play,1),size(play,2));
-    int4d  jeta  ("jeta"  ,2    ,this->get_nflav(),size(play,1),size(play,2));
+    int2d  jtemp ("jtemp"                         ,ncol,nlay);
+    int2d  jpress("jpress"                        ,ncol,nlay);
+    bool2d tropo ("tropo"                         ,ncol,nlay);
+    real6d fmajor("fmajor",2,2,2,this->get_nflav(),ncol,nlay);
+    int4d  jeta  ("jeta"  ,2    ,this->get_nflav(),ncol,nlay);
     // Gas optics
     compute_gas_taus(top_at_1, ncol, nlay, ngpt, nband, play, plev, tlay, gas_desc, optical_props, jtemp, jpress,
                      jeta, tropo, fmajor, col_dry);
@@ -833,7 +832,6 @@ public:
     #endif
 
     if (allocated(tlev)) {
-      if (size(tlev,1) != ncol || size(tlev,2) != nlay+1) { stoprun("gas_optics(): array tlev has wrong size"); }
       #ifdef RRTMGP_EXPENSIVE_CHECKS
         if (anyLT(tlev,this->temp_ref_min) || anyGT(tlev,this->temp_ref_max)) {
           stoprun("gas_optics(): array tlev has values outside range");
@@ -854,21 +852,20 @@ public:
 
   // Compute gas optical depth given temperature, pressure, and composition
   template <class T>
-  void gas_optics(bool top_at_1, real2d const &play, real2d const &plev, real2d const &tlay, GasConcs const &gas_desc,   
+  void gas_optics(const int ncol, const int nlay,
+                  bool top_at_1, real2d const &play, real2d const &plev, real2d const &tlay, GasConcs const &gas_desc,
                   T &optical_props, real2d &toa_src, real2d const &col_dry=real2d()) {
-    int ncol  = size(play,1);
-    int nlay  = size(play,2);
     int ngpt  = this->get_ngpt();
     int nband = this->get_nband();
     int ngas  = this->get_ngas();
     int nflav = get_nflav();
     
     // Interpolation coefficients for use in source function
-    int2d  jtemp ("jtemp"                         ,size(play,1),size(play,2));
-    int2d  jpress("jpress"                        ,size(play,1),size(play,2));
-    bool2d tropo ("tropo"                         ,size(play,1),size(play,2));
-    real6d fmajor("fmajor",2,2,2,this->get_nflav(),size(play,1),size(play,2));
-    int4d  jeta  ("jeta  ",2    ,this->get_nflav(),size(play,1),size(play,2));
+    int2d  jtemp ("jtemp"                         ,ncol,nlay);
+    int2d  jpress("jpress"                        ,ncol,nlay);
+    bool2d tropo ("tropo"                         ,ncol,nlay);
+    real6d fmajor("fmajor",2,2,2,this->get_nflav(),ncol,nlay);
+    int4d  jeta  ("jeta  ",2    ,this->get_nflav(),ncol,nlay);
     // Gas optics
     compute_gas_taus(top_at_1, ncol, nlay, ngpt, nband, play, plev, tlay, gas_desc, optical_props, jtemp, jpress, jeta,
                      tropo, fmajor, col_dry);
@@ -909,10 +906,6 @@ public:
     if (! this->is_initialized()) { stoprun("ERROR: spectral configuration not loaded"); }
     // Check for presence of key species in ty_gas_concs; return error if any key species are not present
     this->check_key_species_present(gas_desc);
-    // Check input data sizes and values
-    if (size(play,1) != ncol || size(play,2) != nlay  ) { stoprun("gas_optics(): array play has wrong size"); }
-    if (size(tlay,1) != ncol || size(tlay,2) != nlay  ) { stoprun("gas_optics(): array tlay has wrong size"); }
-    if (size(plev,1) != ncol || size(plev,2) != nlay+1) { stoprun("gas_optics(): array plev has wrong size"); }
     #ifdef RRTMGP_EXPENSIVE_CHECKS
       if ( anyLT(play,this->press_ref_min) || anyGT(play,this->press_ref_max) ) {
         stoprun("gas_optics(): array play has values outside range");

--- a/cpp/rte/mo_fluxes.h
+++ b/cpp/rte/mo_fluxes.h
@@ -35,29 +35,7 @@ public:
     int ncol = size(gpt_flux_up,1);
     int nlev = size(gpt_flux_up,2);
     int ngpt = size(gpt_flux_up,3);
-    // Check array sizes
-    //  Input arrays
-    if (size(gpt_flux_dn,1) != ncol || size(gpt_flux_dn,2) != nlev || size(gpt_flux_dn,3) != ngpt) {
-      stoprun("reduce: gpt_flux_dn array incorrectly sized");
-    }
-    if (allocated(gpt_flux_dn_dir)) {
-      if (size(gpt_flux_dn_dir,1) != ncol || size(gpt_flux_dn_dir,2) != nlev || size(gpt_flux_dn_dir,3) != ngpt) {
-        stoprun("reduce: gpt_flux_dn_dir array incorrectly sized");
-      }
-    }
-    // Output arrays
-    if (allocated(this->flux_up)) {
-      if (size(this->flux_up,1) != ncol || size(this->flux_up,2) != nlev) { stoprun("reduce: flux_up array incorrectly sized"); }
-    }
-    if (allocated(this->flux_dn)) {
-      if (size(this->flux_dn,1) != ncol || size(this->flux_dn,2) != nlev) { stoprun("reduce: flux_dn array incorrectly sized"); }
-    }
-    if (allocated(this->flux_net)) {
-      if (size(this->flux_net,1) != ncol || size(this->flux_net,2) != nlev) { stoprun("reduce: flux_net array incorrectly sized"); }
-    }
-    if (allocated(this->flux_dn_dir)) {
-      if (size(this->flux_dn_dir,1) != ncol || size(this->flux_dn_dir,2) != nlev) { stoprun("reduce: flux_dn_dir array incorrectly sized"); }
-    }
+
     // Self-consistency -- shouldn't be asking for direct beam flux if it isn't supplied
     if (allocated(this->flux_dn_dir) && ! allocated(gpt_flux_dn_dir)) {
       stoprun("reduce: requesting direct downward flux but this hasn't been supplied");

--- a/cpp/rte/mo_rte_lw.h
+++ b/cpp/rte/mo_rte_lw.h
@@ -46,12 +46,12 @@
 
 // Interface using only optical properties and source functions as inputs; fluxes as outputs.
 template <class FluxesType>
-void rte_lw(int max_gauss_pts, real2d const &gauss_Ds, real2d const &gauss_wts, OpticalProps1scl const &optical_props, 
+void rte_lw(int max_gauss_pts, real2d const &gauss_Ds, real2d const &gauss_wts, OpticalProps1scl const &optical_props,
             bool top_at_1, SourceFuncLW const &sources, real2d const &sfc_emis,
             FluxesType &fluxes, real2d const &inc_flux=real2d(), int n_gauss_angles=-1);
 
 template <class FluxesType>
-void rte_lw(int max_gauss_pts, real2d const &gauss_Ds, real2d const &gauss_wts, OpticalProps1scl const &optical_props, 
+void rte_lw(int max_gauss_pts, real2d const &gauss_Ds, real2d const &gauss_wts, OpticalProps1scl const &optical_props,
             bool top_at_1, SourceFuncLW const &sources, real2d const &sfc_emis,
             FluxesType &fluxes, real2d const &inc_flux, int n_gauss_angles) {
   real3d gpt_flux_up;
@@ -98,7 +98,7 @@ void rte_lw(int max_gauss_pts, real2d const &gauss_Ds, real2d const &gauss_wts, 
     }
     n_quad_angs = n_gauss_angles;
   }
-  
+
   // Ensure values of tau, ssa, and g are reasonable
   optical_props.validate();
 
@@ -107,7 +107,7 @@ void rte_lw(int max_gauss_pts, real2d const &gauss_Ds, real2d const &gauss_wts, 
   gpt_flux_dn  = real3d("gpt_flux_dn" ,ncol,nlay+1,ngpt);
   sfc_emis_gpt = real2d("sfc_emis_gpt",ncol       ,ngpt);
   expand_and_transpose(optical_props, sfc_emis, sfc_emis_gpt);
-  
+
   //   Upper boundary condition
   if (allocated(inc_flux)) {
     apply_BC(ncol, nlay, ngpt, top_at_1, inc_flux, gpt_flux_dn);
@@ -126,8 +126,8 @@ void rte_lw(int max_gauss_pts, real2d const &gauss_Ds, real2d const &gauss_wts, 
     tmp_Ds (i) = gauss_Ds (i,n_quad_angs);
     tmp_wts(i) = gauss_wts(i,n_quad_angs);
   });
-  lw_solver_noscat_GaussQuad(ncol, nlay, ngpt, top_at_1, n_quad_angs, tmp_Ds, tmp_wts, optical_props.tau,                                                  
-                             sources.lay_source, sources.lev_source_inc, sources.lev_source_dec, 
+  lw_solver_noscat_GaussQuad(ncol, nlay, ngpt, top_at_1, n_quad_angs, tmp_Ds, tmp_wts, optical_props.tau,
+                             sources.lay_source, sources.lev_source_inc, sources.lev_source_dec,
                              sfc_emis_gpt, sources.sfc_source, gpt_flux_up, gpt_flux_dn);
   // ...and reduce spectral fluxes to desired output quantities
   fluxes.reduce(gpt_flux_up, gpt_flux_dn, optical_props, top_at_1);


### PR DESCRIPTION
This PR makes `ncol` and `nlay` inputs of a few functions (instead of querying dimensions of arrays). This is so that radiation can be called from shoc with padded arrays. 

Note: I didn't change every instance, only when having the exact value are necessary. I don't mind changing every instance if that it what others think.