### PR TITLE
Enable building RRTMGPXX as a library with CUDA

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CXX_SRC
 )
 
 # Add RRTMGP as a library and make sure we link against YAKL
-add_library(rrtmgp ${CXX_SRC})
+add_library(rrtmgp STATIC ${CXX_SRC})
 target_link_libraries(rrtmgp yakl)
 
 # Special compile flags for C++ source
@@ -23,7 +23,6 @@ set_source_files_properties(${CXX_SRC} PROPERTIES COMPILE_FLAGS "${CPPDEFS} ${YA
 if ("${ARCH}" STREQUAL "CUDA")
   enable_language(CUDA)
   set_source_files_properties(${CXX_SRC} PROPERTIES LANGUAGE CUDA)
-  set_source_files_properties(${CXX_SRC} PROPERTIES COMPILE_FLAGS "${CUDA_FLAGS}")
   set_target_properties(rrtmgp PROPERTIES LINKER_LANGUAGE CUDA CUDA_SEPARABLE_COMPILATION OFF CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 endif()
 target_include_directories(rrtmgp PUBLIC ${YAKL_HOME})

--- a/cpp/examples/all-sky/CMakeLists.txt
+++ b/cpp/examples/all-sky/CMakeLists.txt
@@ -1,29 +1,16 @@
 cmake_minimum_required(VERSION 3.0)
 project(standalone)
 
-# NOTE: Ideally, we would build rrtmgp as a library before building the
-# the standalone code. However, this does not seem to be linking properly for
-# GPU builds at the moment, so pull in all the RRTMGP source instead
-set(RRTMGP_SRC
-  ../../rrtmgp/kernels/mo_gas_optics_kernels.cpp
-  ../../rrtmgp/mo_rrtmgp_constants.cpp
-  ../../rrtmgp/mo_rrtmgp_util_reorder.cpp
-  ../../rte/expand_and_transpose.cpp
-  ../../rte/kernels/mo_fluxes_broadband_kernels.cpp
-  ../../rte/kernels/mo_optical_props_kernels.cpp
-  ../../rte/kernels/mo_rte_solver_kernels.cpp
-)
 set(CPP_SRC 
     ../mo_load_coefficients.cpp
     ../../extensions/fluxes_byband/mo_fluxes_byband_kernels.cpp
     mo_garand_atmos_io.cpp 
     mo_load_cloud_coefficients.cpp
     rrtmgp_allsky.cpp
-    ${RRTMGP_SRC}
 )
 add_executable(allsky ${CPP_SRC})
 
-target_link_libraries(allsky yakl ${NCFLAGS})
+target_link_libraries(allsky yakl rrtmgp ${NCFLAGS})
 target_compile_features(allsky PUBLIC cxx_std_14)
 target_include_directories(allsky PUBLIC ../)
 target_include_directories(allsky PUBLIC ../../)

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -12,8 +12,8 @@ endif()
 # but that does not seem to be working for GPU builds on summit right now for
 # some reason (leads to segfaults). So instead, the allsky build will just pull
 # in all the RRTMGP source and build and link all at once.
-#add_subdirectory(../ ./rrtmgp)
 add_subdirectory(${YAKL_HOME} ./yakl)
+add_subdirectory(../ ./rrtmgp)
 add_subdirectory(../examples/all-sky ./allsky)
 
 # Add unit test script commands


### PR DESCRIPTION
Enable building RRTMGPXX as a library. Previously, this would segfault when built using the CUDA backend for GPU. Adding STATIC to the `add_library` statement I think is what fixed it.