### PR TITLE
Rename Array to YAKL_Array in const.h

### DIFF
--- a/cpp/const.h
+++ b/cpp/const.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "YAKL.h"
-#include "Array.h"
+#include "YAKL_Array.h"
 #include <iostream>
 #include <cmath>
 

--- a/cpp/const.h
+++ b/cpp/const.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "YAKL.h"
-#include "YAKL_Array.h"
 #include <iostream>
 #include <cmath>
 


### PR DESCRIPTION
Fixes for updated YAKL. No need to include Array.h (now YAKL_Array.h), can just include YAKL.h.