### PR TITLE
Use new YAKL netcdf-c interface instead of netcdf-cxx4

### DIFF
--- a/cpp/test/fhqwhgads_cpu.sh
+++ b/cpp/test/fhqwhgads_cpu.sh
@@ -4,7 +4,7 @@ unset ARCH
 unset CUDA_ARCH
 unset CUBHOME
 
-export NCFLAGS="`ncxx4-config --libs`"
+export NCFLAGS="`nc-config --libs`"
 export CC=gcc
 export CXX=g++
 export CXXFLAGS="-O3"

--- a/cpp/test/fhqwhgads_gpu.sh
+++ b/cpp/test/fhqwhgads_gpu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export NCFLAGS="`ncxx4-config --libs`"
+export NCFLAGS="`nc-config --libs`"
 export CC=gcc
 export CXX=g++
 export CXXFLAGS="-O3"

--- a/cpp/test/lyra_cpu.sh
+++ b/cpp/test/lyra_cpu.sh
@@ -9,7 +9,7 @@ unset CUBHOME
 unset ROCPRIMHOME
 unset HIPCUBHOME
 
-export NCFLAGS="`/ccs/home/${USER}/libs_gnu8.1.0/netcdf-4.3.3.1_gnu/bin/ncxx4-config --libs` `/ccs/home/${USER}/libs_gnu8.1.0/netcdf-4.3.3.1_gnu/bin/nc-config --libs`"
+export NCFLAGS="`/ccs/home/${USER}/libs_gnu8.1.0/netcdf-4.3.3.1_gnu/bin/nc-config --libs`"
 export CC=gcc
 export CXX=g++
 export CXXFLAGS="-O3 -I/ccs/home/${USER}/libs_gnu8.1.0/netcdf-4.3.3.1_gnu/include"

--- a/cpp/test/lyra_gpu.sh
+++ b/cpp/test/lyra_gpu.sh
@@ -3,7 +3,7 @@
 source $MODULESHOME/init/bash
 module load gcc hip cmake
 
-export NCFLAGS="`/ccs/home/imn/libs_hip/netcdf-4.3.3.1/bin/ncxx4-config --libs` `/ccs/home/imn/libs_gnu8.1.0/netcdf-4.3.3.1_gnu/bin/nc-config --libs`"
+export NCFLAGS="`/ccs/home/imn/libs_gnu8.1.0/netcdf-4.3.3.1_gnu/bin/nc-config --libs`"
 export CC=gcc
 export CXX=hipcc
 export CXXFLAGS="-O3 -I/ccs/home/imn/libs_hip/netcdf-4.3.3.1/include -I/ccs/home/imn/libs_gnu8.1.0/netcdf-4.3.3.1_gnu/include"

--- a/cpp/test/macbook.sh
+++ b/cpp/test/macbook.sh
@@ -6,10 +6,10 @@ unset ARCH
 unset CUDA_ARCH
 unset CUBHOME
 
-export NCFLAGS="`ncxx4-config --libs`"
+export NCFLAGS="`nc-config --libs`"
 export NFFLAGS="`nc-config --flibs` -lnetcdf -lnetcdff"
 export CC=gcc
 export CXX=g++
-export CXXFLAGS="-O3 -I`ncxx4-config --includedir`"
+export CXXFLAGS="-O3 -I`nc-config --includedir`"
 export F90FLAGS="-O3 -I`nc-config --fflags`"
 export YAKLHOME="${HOME}/codes/yakl/YAKL"

--- a/cpp/test/mappy.sh
+++ b/cpp/test/mappy.sh
@@ -9,7 +9,7 @@ unset ARCH
 unset CUDA_ARCH
 unset CUBHOME
 
-export NCFLAGS="`ncxx4-config --libs`"
+export NCFLAGS="`nc-config --libs`"
 export CC=gcc
 export CXX=g++
 export CXXFLAGS="-O3"

--- a/cpp/test/summit_cpu.sh
+++ b/cpp/test/summit_cpu.sh
@@ -2,14 +2,14 @@
 
 source $MODULESHOME/init/bash
 module purge
-module load DefApps gcc cmake cuda netcdf-cxx4 netcdf nco
+module load DefApps gcc cmake cuda netcdf-c nco
 
 unset ARCH
 unset CUDA_ARCH
 unset CUBHOME
 
-export NCINCLUDE="`ncxx4-config --includedir`;`nc-config --includedir`" # must be semi-colon seperated
-export NCFLAGS="`ncxx4-config --libs` `nc-config --libs`"
+export NCINCLUDE="`nc-config --includedir`"
+export NCFLAGS="`nc-config --libs`"
 export CC=gcc
 export CXX=g++
 export CXXFLAGS="-O3"

--- a/cpp/test/summit_gpu.sh
+++ b/cpp/test/summit_gpu.sh
@@ -2,15 +2,15 @@
 
 source $MODULESHOME/init/bash
 module purge
-module load DefApps gcc cmake cuda netcdf-cxx4 netcdf nco
+module load DefApps gcc cmake cuda netcdf-c nco
 
-export NCINCLUDE="`ncxx4-config --includedir`;`nc-config --includedir`" # must be semi-colon seperated
-export NCFLAGS="`ncxx4-config --libs` `nc-config --libs`"
+export NCINCLUDE="`nc-config --includedir`"
+export NCFLAGS="`nc-config --libs`"
 export CC=gcc
 export CXX=g++
 export CXXFLAGS="-O3"
 export ARCH="CUDA"
-export YAKL_CUDA_FLAGS="-arch sm_70 --use_fast_math -O3"
+export YAKL_CUDA_FLAGS="-arch sm_70 --use_fast_math -O3 -DTHRUST_IGNORE_CUB_VERSION_CHECK"
 export CUBHOME="/ccs/home/$USER/cub"
 export YAKLHOME="/ccs/home/$USER/YAKL"
 

--- a/cpp/test/thatchroof_cpu.sh
+++ b/cpp/test/thatchroof_cpu.sh
@@ -8,8 +8,8 @@ unset ARCH
 unset CUDA_ARCH
 unset CUBHOME
 
-export NCINCLUDE="`ncxx4-config --includedir`;`nc-config --includedir`" # must be semi-colon seperated
-export NCFLAGS="`ncxx4-config --libs` `nc-config --libs`"
+export NCINCLUDE="`nc-config --includedir`"
+export NCFLAGS="`nc-config --libs`"
 export CC=gcc
 export CXX=g++
 export CXXFLAGS="-O3"

--- a/cpp/test/thatchroof_gpu.sh
+++ b/cpp/test/thatchroof_gpu.sh
@@ -4,8 +4,8 @@ source $MODULESHOME/init/bash
 module purge
 module load cmake netcdf
 
-export NCINCLUDE="`ncxx4-config --includedir`;`nc-config --includedir`" # must be semi-colon seperated
-export NCFLAGS="`ncxx4-config --libs`"
+export NCINCLUDE="`nc-config --includedir`"
+export NCFLAGS="`nc-config --libs`"
 export CC=gcc
 export CXX=g++
 export CXXFLAGS="-O3"

--- a/cpp/test/tulip_cpu.sh
+++ b/cpp/test/tulip_cpu.sh
@@ -4,8 +4,8 @@ module load/9.2.0
 module load cuda11.1/toolkit/11.1.1
 spack load netcdf-cxx4%gcc
 
-export NCINCLUDE="`ncxx4-config --includedir`;`nc-config --includedir`" # must be semi-colon seperated
-export NCFLAGS="`ncxx4-config --libs` `nc-config --libs`"
+export NCINCLUDE="`nc-config --includedir`"
+export NCFLAGS="`nc-config --libs`"
 export CC=gcc
 export CXX=g++
 export CXXFLAGS="-O3"

--- a/cpp/test/tulip_gpu.sh
+++ b/cpp/test/tulip_gpu.sh
@@ -4,8 +4,8 @@ module load/9.2.0
 module load cuda11.1/toolkit/11.1.1
 spack load netcdf-cxx4%gcc
 
-export NCINCLUDE="`ncxx4-config --includedir`;`nc-config --includedir`" # must be semi-colon seperated
-export NCFLAGS="`ncxx4-config --libs` `nc-config --libs`"
+export NCINCLUDE="`nc-config --includedir`"
+export NCFLAGS="`nc-config --libs`"
 export CC=gcc
 export CXX=g++
 export CXXFLAGS="-O3"


### PR DESCRIPTION
Use new YAKL netcdf-c interface instead of netcdf-cxx4. This removes the dependency on a netcdf library built with the netcdf-cxx4 interface. Since this is a non-user-facing change in YAKL, all that is required here is to remove dependence on netcdf-cxx4 modules in the machine-specific configuration files.