### PR TITLE
No more CUDA-related warnings

### DIFF
--- a/cpp/const.h
+++ b/cpp/const.h
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <cmath>
 
-template <class T, int rank, int myMem, int myAttr = yakl::attrManaged> using FArray = yakl::Array<T,rank,myMem,yakl::styleFortran,myAttr>;
+template <class T, int rank, int myMem> using FArray = yakl::Array<T,rank,myMem,yakl::styleFortran>;
 
 typedef double real;
 
@@ -27,17 +27,15 @@ using yakl::intrinsics::count;
 using yakl::intrinsics::allocated;
 using yakl::memHost;
 using yakl::memDevice;
-using yakl::attrManaged;
-using yakl::attrUnmanaged;
 
 
-typedef FArray<real,1,yakl::memDevice,attrUnmanaged> umgReal1d;
-typedef FArray<real,2,yakl::memDevice,attrUnmanaged> umgReal2d;
-typedef FArray<real,3,yakl::memDevice,attrUnmanaged> umgReal3d;
-typedef FArray<real,4,yakl::memDevice,attrUnmanaged> umgReal4d;
-typedef FArray<real,5,yakl::memDevice,attrUnmanaged> umgReal5d;
-typedef FArray<real,6,yakl::memDevice,attrUnmanaged> umgReal6d;
-typedef FArray<real,7,yakl::memDevice,attrUnmanaged> umgReal7d;
+typedef FArray<real,1,yakl::memDevice> umgReal1d;
+typedef FArray<real,2,yakl::memDevice> umgReal2d;
+typedef FArray<real,3,yakl::memDevice> umgReal3d;
+typedef FArray<real,4,yakl::memDevice> umgReal4d;
+typedef FArray<real,5,yakl::memDevice> umgReal5d;
+typedef FArray<real,6,yakl::memDevice> umgReal6d;
+typedef FArray<real,7,yakl::memDevice> umgReal7d;
 
 typedef FArray<real,1,yakl::memDevice> real1d;
 typedef FArray<real,2,yakl::memDevice> real2d;
@@ -55,13 +53,13 @@ typedef FArray<real,5,yakl::memHost> realHost5d;
 typedef FArray<real,6,yakl::memHost> realHost6d;
 typedef FArray<real,7,yakl::memHost> realHost7d;
 
-typedef FArray<int,1,yakl::memDevice,attrUnmanaged> umgInt1d;
-typedef FArray<int,2,yakl::memDevice,attrUnmanaged> umgInt2d;
-typedef FArray<int,3,yakl::memDevice,attrUnmanaged> umgInt3d;
-typedef FArray<int,4,yakl::memDevice,attrUnmanaged> umgInt4d;
-typedef FArray<int,5,yakl::memDevice,attrUnmanaged> umgInt5d;
-typedef FArray<int,6,yakl::memDevice,attrUnmanaged> umgInt6d;
-typedef FArray<int,7,yakl::memDevice,attrUnmanaged> umgInt7d;
+typedef FArray<int,1,yakl::memDevice> umgInt1d;
+typedef FArray<int,2,yakl::memDevice> umgInt2d;
+typedef FArray<int,3,yakl::memDevice> umgInt3d;
+typedef FArray<int,4,yakl::memDevice> umgInt4d;
+typedef FArray<int,5,yakl::memDevice> umgInt5d;
+typedef FArray<int,6,yakl::memDevice> umgInt6d;
+typedef FArray<int,7,yakl::memDevice> umgInt7d;
 
 typedef FArray<int,1,yakl::memDevice> int1d;
 typedef FArray<int,2,yakl::memDevice> int2d;
@@ -79,13 +77,13 @@ typedef FArray<int,5,yakl::memHost> intHost5d;
 typedef FArray<int,6,yakl::memHost> intHost6d;
 typedef FArray<int,7,yakl::memHost> intHost7d;
 
-typedef FArray<bool,1,yakl::memDevice,attrUnmanaged> umgBool1d;
-typedef FArray<bool,2,yakl::memDevice,attrUnmanaged> umgBool2d;
-typedef FArray<bool,3,yakl::memDevice,attrUnmanaged> umgBool3d;
-typedef FArray<bool,4,yakl::memDevice,attrUnmanaged> umgBool4d;
-typedef FArray<bool,5,yakl::memDevice,attrUnmanaged> umgBool5d;
-typedef FArray<bool,6,yakl::memDevice,attrUnmanaged> umgBool6d;
-typedef FArray<bool,7,yakl::memDevice,attrUnmanaged> umgBool7d;
+typedef FArray<bool,1,yakl::memDevice> umgBool1d;
+typedef FArray<bool,2,yakl::memDevice> umgBool2d;
+typedef FArray<bool,3,yakl::memDevice> umgBool3d;
+typedef FArray<bool,4,yakl::memDevice> umgBool4d;
+typedef FArray<bool,5,yakl::memDevice> umgBool5d;
+typedef FArray<bool,6,yakl::memDevice> umgBool6d;
+typedef FArray<bool,7,yakl::memDevice> umgBool7d;
 
 typedef FArray<bool,1,yakl::memDevice> bool1d;
 typedef FArray<bool,2,yakl::memDevice> bool2d;

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -333,12 +333,13 @@ public:
 
   void combine( int nbnd, int nlay, int ncol, real3d const &ltau, real3d const &itau, real3d const &ltaussa, real3d const &itaussa,
                 real3d const &ltaussag, real3d const &itaussag, OpticalProps1scl &optical_props ) {
+    auto &optical_props_tau = optical_props.tau;
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1,ncol
     parallel_for( Bounds<3>(nbnd,nlay,ncol) , YAKL_LAMBDA (int ibnd, int ilay, int icol) {
       // Absorption optical depth  = (1-ssa) * tau = tau - taussa
-      optical_props.tau(icol,ilay,ibnd) = (ltau(icol,ilay,ibnd) - ltaussa(icol,ilay,ibnd)) +
+      optical_props_tau(icol,ilay,ibnd) = (ltau(icol,ilay,ibnd) - ltaussa(icol,ilay,ibnd)) +
                                           (itau(icol,ilay,ibnd) - itaussa(icol,ilay,ibnd));
     });
   }
@@ -347,15 +348,18 @@ public:
 
   void combine( int nbnd, int nlay, int ncol, real3d const &ltau, real3d const &itau, real3d const &ltaussa, real3d const &itaussa,
                 real3d const &ltaussag, real3d const &itaussag, OpticalProps2str &optical_props ) {
+    auto &optical_props_g   = optical_props.g  ;
+    auto &optical_props_ssa = optical_props.ssa;
+    auto &optical_props_tau = optical_props.tau;
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1,ncol
     parallel_for( Bounds<3>(nbnd,nlay,ncol) , YAKL_LAMBDA (int ibnd, int ilay, int icol) {
       real tau    = ltau   (icol,ilay,ibnd) + itau   (icol,ilay,ibnd);
       real taussa = ltaussa(icol,ilay,ibnd) + itaussa(icol,ilay,ibnd);
-      optical_props.g  (icol,ilay,ibnd) = (ltaussag(icol,ilay,ibnd) + itaussag(icol,ilay,ibnd)) / max(epsilon(tau), taussa);
-      optical_props.ssa(icol,ilay,ibnd) = taussa / max(epsilon(tau), tau);
-      optical_props.tau(icol,ilay,ibnd) = tau;
+      optical_props_g  (icol,ilay,ibnd) = (ltaussag(icol,ilay,ibnd) + itaussag(icol,ilay,ibnd)) / max(epsilon(tau), taussa);
+      optical_props_ssa(icol,ilay,ibnd) = taussa / max(epsilon(tau), tau);
+      optical_props_tau(icol,ilay,ibnd) = tau;
     });
   }
 

--- a/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
+++ b/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
@@ -1037,10 +1037,11 @@ public:
                           this->get_gpoint_bands(), this->get_band_lims_gpoint(), this->planck_frac, this->temp_ref_min,
                           this->totplnk_delta, this->totplnk, this->gpoint_flavor, sfc_source_t, lay_source_t, lev_source_inc_t,
                           lev_source_dec_t);
+    auto &sources_sfc_source = sources.sfc_source;
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
     parallel_for( Bounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
-      sources.sfc_source(icol,igpt) = sfc_source_t(igpt,icol);
+      sources_sfc_source(icol,igpt) = sfc_source_t(igpt,icol);
     });
     reorder123x321(ngpt, nlay, ncol, lay_source_t    , sources.lay_source    );
     reorder123x321(ngpt, nlay, ncol, lev_source_inc_t, sources.lev_source_inc);

--- a/cpp/rte/mo_optical_props.h
+++ b/cpp/rte/mo_optical_props.h
@@ -80,7 +80,7 @@ public:
   }
 
 
-  YAKL_INLINE bool is_initialized() const { return allocated(this->band2gpt); }
+  bool is_initialized() const { return allocated(this->band2gpt); }
 
 
   // Base class: finalize (deallocate memory)
@@ -93,14 +93,14 @@ public:
 
 
   // Number of bands
-  YAKL_INLINE int get_nband() const {
+  int get_nband() const {
     if (this->is_initialized()) { return size(this->band2gpt,2); }
     return 0;
   }
 
 
   // Number of g-points
-  YAKL_INLINE int get_ngpt() const {
+  int get_ngpt() const {
     if (this->is_initialized()) { return this->ngpt; }
     return 0;
   }
@@ -164,8 +164,9 @@ public:
     // for (int j=1 ; j <= size(this->band_lims_wvn,2); j++) {
     //   for (int i=1 ; i <= size(this->band_lims_wvn,1); i++) {
     auto &this_band_lims_wvn = this->band_lims_wvn;
+    auto &rhs_band_lims_wvn  = rhs.band_lims_wvn;
     parallel_for( Bounds<2>( size(this->band_lims_wvn,2) , size(this->band_lims_wvn,1) ) , YAKL_LAMBDA (int j, int i) {
-      if ( abs( this_band_lims_wvn(i,j) - rhs.band_lims_wvn(i,j) ) > 5*epsilon(this_band_lims_wvn) ) {
+      if ( abs( this_band_lims_wvn(i,j) - rhs_band_lims_wvn(i,j) ) > 5*epsilon(this_band_lims_wvn) ) {
         ret = false;
       }
     });
@@ -180,8 +181,9 @@ public:
     yakl::ScalarLiveOut<bool> ret(true);
     // for (int i=1; i <= size(this->gpt2bnd,1); i++) {
     auto &this_gpt2band = this->gpt2band;
+    auto &rhs_gpt2band  = rhs.gpt2band;
     parallel_for( Bounds<1>(size(this->gpt2band,1)) , YAKL_LAMBDA (int i) {
-      if ( this_gpt2band(i) != rhs.gpt2band(i) ) { ret = false; }
+      if ( this_gpt2band(i) != rhs_gpt2band(i) ) { ret = false; }
     });
     return ret.hostRead();
   }
@@ -193,8 +195,9 @@ public:
     // do iband=1,this->get_nband()
     // TODO: I don't know if this needs to be serialize or not at first glance. Need to look at it more.
     auto &this_band2gpt = this->gpt2band;
+    int nband = get_nband();
     parallel_for( Bounds<1>(1) , YAKL_LAMBDA (int dummy) {
-      for (int iband = 1 ; iband <= get_nband() ; iband++) {
+      for (int iband = 1 ; iband <= nband ; iband++) {
         for (int i=this_band2gpt(1,iband) ; i <= this_band2gpt(2,iband) ; i++) {
           ret(i) = arr_in(iband);
         }
@@ -216,8 +219,8 @@ class OpticalPropsArry : public OpticalProps {
 public:
   real3d tau; // optical depth (ncol, nlay, ngpt)
 
-  YAKL_INLINE int get_ncol() const { if (allocated(tau)) { return size(this->tau,1); } else { return 0; } }
-  YAKL_INLINE int get_nlay() const { if (allocated(tau)) { return size(this->tau,2); } else { return 0; } }
+  int get_ncol() const { if (allocated(tau)) { return size(this->tau,1); } else { return 0; } }
+  int get_nlay() const { if (allocated(tau)) { return size(this->tau,2); } else { return 0; } }
 };
 
 


### PR DESCRIPTION
Updating to latest YAKL master (confirmed works with YAKL hash 9187f44aa3bc7738f61f10225f8b5c3272cfa8f3)

Removing `attrUnmanaged` template parameter from `Array` objects. 

Got rid of all instances where rrtmgpxx class objects get copied by value into lambdas. Also got rid of all instances of using `this->` inside a `YAKL_INLINE` function.

No CUDA-related warnings occur in rrtmgpxx anymore.