### PR TITLE
remove the double float literals which is not supported on sycl gpu code

### DIFF
--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -112,9 +112,9 @@ int main(int argc , char **argv) {
       real2d sfc_alb_dif("sfc_alb_dif",nbnd,ncol);
       real1d mu0        ("mu0"        ,ncol);
       // Ocean-ish values for no particular reason
-      sfc_alb_dir = 0.06_wp;
-      sfc_alb_dif = 0.06_wp;
-      mu0         = 0.86_wp;
+      sfc_alb_dir = 0.06;
+      sfc_alb_dif = 0.06;
+      mu0         = 0.86;
 
       // Fluxes
       real2d flux_up ("flux_up" ,ncol,nlay+1);
@@ -140,12 +140,12 @@ int main(int argc , char **argv) {
       // do ilay=1,nlay
       //   do icol=1,ncol
       parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
-        cloud_mask(icol,ilay) = p_lay(icol,ilay) > 100._wp * 100._wp && p_lay(icol,ilay) < 900._wp * 100._wp && mod(icol, 3) != 0;
+        cloud_mask(icol,ilay) = p_lay(icol,ilay) > 100. * 100. && p_lay(icol,ilay) < 900. * 100. && mod(icol, 3) != 0;
         // Ice and liquid will overlap in a few layers
-        lwp(icol,ilay) = merge(10._wp,  0._wp, cloud_mask(icol,ilay) && t_lay(icol,ilay) > 263._wp);
-        iwp(icol,ilay) = merge(10._wp,  0._wp, cloud_mask(icol,ilay) && t_lay(icol,ilay) < 273._wp);
-        rel(icol,ilay) = merge(rel_val, 0._wp, lwp(icol,ilay) > 0._wp);
-        rei(icol,ilay) = merge(rei_val, 0._wp, iwp(icol,ilay) > 0._wp);
+        lwp(icol,ilay) = merge(10.,  0., cloud_mask(icol,ilay) && t_lay(icol,ilay) > 263.);
+        iwp(icol,ilay) = merge(10.,  0., cloud_mask(icol,ilay) && t_lay(icol,ilay) < 273.);
+        rel(icol,ilay) = merge(rel_val, 0., lwp(icol,ilay) > 0.);
+        rei(icol,ilay) = merge(rei_val, 0., iwp(icol,ilay) > 0.);
       });
 
       if (verbose) std::cout << "Running the main loop\n\n";
@@ -199,16 +199,16 @@ int main(int argc , char **argv) {
       //   after Abramowitz & Stegun 1972, page 921
       int constexpr max_gauss_pts = 4;
       realHost2d gauss_Ds_host ("gauss_Ds" ,max_gauss_pts,max_gauss_pts);
-      gauss_Ds_host(1,1) = 1.66_wp      ; gauss_Ds_host(2,1) =         0._wp; gauss_Ds_host(3,1) =         0._wp; gauss_Ds_host(4,1) =         0._wp;
-      gauss_Ds_host(1,2) = 1.18350343_wp; gauss_Ds_host(2,2) = 2.81649655_wp; gauss_Ds_host(3,2) =         0._wp; gauss_Ds_host(4,2) =         0._wp;
-      gauss_Ds_host(1,3) = 1.09719858_wp; gauss_Ds_host(2,3) = 1.69338507_wp; gauss_Ds_host(3,3) = 4.70941630_wp; gauss_Ds_host(4,3) =         0._wp;
-      gauss_Ds_host(1,4) = 1.06056257_wp; gauss_Ds_host(2,4) = 1.38282560_wp; gauss_Ds_host(3,4) = 2.40148179_wp; gauss_Ds_host(4,4) = 7.15513024_wp;
+      gauss_Ds_host(1,1) = 1.66      ; gauss_Ds_host(2,1) =         0.; gauss_Ds_host(3,1) =         0.; gauss_Ds_host(4,1) =         0.;
+      gauss_Ds_host(1,2) = 1.18350343; gauss_Ds_host(2,2) = 2.81649655; gauss_Ds_host(3,2) =         0.; gauss_Ds_host(4,2) =         0.;
+      gauss_Ds_host(1,3) = 1.09719858; gauss_Ds_host(2,3) = 1.69338507; gauss_Ds_host(3,3) = 4.70941630; gauss_Ds_host(4,3) =         0.;
+      gauss_Ds_host(1,4) = 1.06056257; gauss_Ds_host(2,4) = 1.38282560; gauss_Ds_host(3,4) = 2.40148179; gauss_Ds_host(4,4) = 7.15513024;
 
       realHost2d gauss_wts_host("gauss_wts",max_gauss_pts,max_gauss_pts);
-      gauss_wts_host(1,1) = 0.5_wp         ; gauss_wts_host(2,1) = 0._wp          ; gauss_wts_host(3,1) = 0._wp          ; gauss_wts_host(4,1) = 0._wp          ;
-      gauss_wts_host(1,2) = 0.3180413817_wp; gauss_wts_host(2,2) = 0.1819586183_wp; gauss_wts_host(3,2) = 0._wp          ; gauss_wts_host(4,2) = 0._wp          ;
-      gauss_wts_host(1,3) = 0.2009319137_wp; gauss_wts_host(2,3) = 0.2292411064_wp; gauss_wts_host(3,3) = 0.0698269799_wp; gauss_wts_host(4,3) = 0._wp          ;
-      gauss_wts_host(1,4) = 0.1355069134_wp; gauss_wts_host(2,4) = 0.2034645680_wp; gauss_wts_host(3,4) = 0.1298475476_wp; gauss_wts_host(4,4) = 0.0311809710_wp;
+      gauss_wts_host(1,1) = 0.5         ; gauss_wts_host(2,1) = 0.          ; gauss_wts_host(3,1) = 0.          ; gauss_wts_host(4,1) = 0.          ;
+      gauss_wts_host(1,2) = 0.3180413817; gauss_wts_host(2,2) = 0.1819586183; gauss_wts_host(3,2) = 0.          ; gauss_wts_host(4,2) = 0.          ;
+      gauss_wts_host(1,3) = 0.2009319137; gauss_wts_host(2,3) = 0.2292411064; gauss_wts_host(3,3) = 0.0698269799; gauss_wts_host(4,3) = 0.          ;
+      gauss_wts_host(1,4) = 0.1355069134; gauss_wts_host(2,4) = 0.2034645680; gauss_wts_host(3,4) = 0.1298475476; gauss_wts_host(4,4) = 0.0311809710;
 
       real2d gauss_Ds ("gauss_Ds" ,max_gauss_pts,max_gauss_pts);
       real2d gauss_wts("gauss_wts",max_gauss_pts,max_gauss_pts);
@@ -235,7 +235,7 @@ int main(int argc , char **argv) {
       // Surface temperature
       auto t_lev_host = t_lev.createHostCopy();
       t_sfc    = t_lev_host(1, merge(nlay+1, 1, top_at_1));
-      emis_sfc = 0.98_wp                                  ;
+      emis_sfc = 0.98                                  ;
 
       // Fluxes
       real2d flux_up ( "flux_up" ,ncol,nlay+1);
@@ -261,12 +261,12 @@ int main(int argc , char **argv) {
       // do ilay=1,nlay
       //   do icol=1,ncol
       parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
-        cloud_mask(icol,ilay) = p_lay(icol,ilay) > 100._wp * 100._wp && p_lay(icol,ilay) < 900._wp * 100._wp && mod(icol, 3) != 0;
+        cloud_mask(icol,ilay) = p_lay(icol,ilay) > 100. * 100. && p_lay(icol,ilay) < 900. * 100. && mod(icol, 3) != 0;
         // Ice and liquid will overlap in a few layers
-        lwp(icol,ilay) = merge(10._wp,  0._wp, cloud_mask(icol,ilay) && t_lay(icol,ilay) > 263._wp);
-        iwp(icol,ilay) = merge(10._wp,  0._wp, cloud_mask(icol,ilay) && t_lay(icol,ilay) < 273._wp);
-        rel(icol,ilay) = merge(rel_val, 0._wp, lwp(icol,ilay) > 0._wp);
-        rei(icol,ilay) = merge(rei_val, 0._wp, iwp(icol,ilay) > 0._wp);
+        lwp(icol,ilay) = merge(10.,  0., cloud_mask(icol,ilay) && t_lay(icol,ilay) > 263.);
+        iwp(icol,ilay) = merge(10.,  0., cloud_mask(icol,ilay) && t_lay(icol,ilay) < 273.);
+        rel(icol,ilay) = merge(rel_val, 0., lwp(icol,ilay) > 0.);
+        rei(icol,ilay) = merge(rei_val, 0., iwp(icol,ilay) > 0.);
       });
 
       // Multiple iterations for big problem sizes, and to help identify data movement

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -114,8 +114,8 @@ public:
 
     this->liq_nsteps = nsize_liq;
     this->ice_nsteps = nsize_ice;
-    this->liq_step_size = (radliq_upr - radliq_lwr) / (nsize_liq-1._wp);
-    this->ice_step_size = (radice_upr - radice_lwr) / (nsize_ice-1._wp);
+    this->liq_step_size = (radliq_upr - radliq_lwr) / (nsize_liq-1.);
+    this->ice_step_size = (radice_upr - radice_lwr) / (nsize_ice-1.);
     // Load LUT constants
     this->radliq_lwr = radliq_lwr;
     this->radliq_upr = radliq_upr;
@@ -280,8 +280,8 @@ public:
     // do ilay = 1, nlay
     //   do icol = 1, ncol
     parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
-      liqmsk(icol,ilay) = clwp(icol,ilay) > 0._wp;
-      icemsk(icol,ilay) = ciwp(icol,ilay) > 0._wp;
+      liqmsk(icol,ilay) = clwp(icol,ilay) > 0.;
+      icemsk(icol,ilay) = ciwp(icol,ilay) > 0.;
     });
 
     #ifdef RRTMGP_EXPENSIVE_CHECKS
@@ -292,7 +292,7 @@ public:
       if ( any(icemsk && (reice < this->radice_lwr)) || any(icemsk && (reice > this->radice_upr)) ) {
         stoprun("cloud optics: ice effective radius is out of bounds");
       }
-      if ( any(liqmsk && (clwp < 0._wp)) || any(icemsk && (ciwp < 0._wp)) ) {
+      if ( any(liqmsk && (clwp < 0.)) || any(icemsk && (ciwp < 0.)) ) {
         stoprun("cloud optics: negative clwp or ciwp where clouds are supposed to be");
       }
     #endif
@@ -441,7 +441,7 @@ public:
     //     do icol = 1, ncol
     parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlay,ncol) , YAKL_LAMBDA (int ibnd, int ilay, int icol) {
       if (mask(icol,ilay)) {
-        int index = std::min( floor( (re(icol,ilay) - offset) / step_size)+1, nsteps-1._wp);
+        int index = std::min( floor( (re(icol,ilay) - offset) / step_size)+1, nsteps-1.);
         real fint = (re(icol,ilay) - offset)/step_size - (index-1);
         real t   = lwp(icol,ilay)    * (tau_table(index,  ibnd) + fint * (tau_table(index+1,ibnd) - tau_table(index,ibnd)));
         real ts  = t                 * (ssa_table(index,  ibnd) + fint * (ssa_table(index+1,ibnd) - ssa_table(index,ibnd)));
@@ -476,14 +476,14 @@ public:
         // Finds index into size regime table
         // This works only if there are precisely three size regimes (four bounds) and it's
         //   previously guaranteed that size_bounds(1) <= size <= size_bounds(4)
-        irad = std::min(floor((re(icol,ilay) - re_bounds_ext(2))/re_bounds_ext(3))+2, 3._wp);
+        irad = std::min(floor((re(icol,ilay) - re_bounds_ext(2))/re_bounds_ext(3))+2, 3.);
         real t = lwp(icol,ilay) *         pade_eval(ibnd, nbnd, nsizes, m_ext, n_ext, irad, re(icol,ilay), coeffs_ext);
 
-        irad = std::min(floor((re(icol,ilay) - re_bounds_ssa(2))/re_bounds_ssa(3))+2, 3._wp);
+        irad = std::min(floor((re(icol,ilay) - re_bounds_ssa(2))/re_bounds_ssa(3))+2, 3.);
         // Pade approximants for co-albedo can sometimes be negative
-        real ts = t * (1._wp - std::max(0._wp, pade_eval(ibnd, nbnd, nsizes, m_ssa, n_ssa, irad, re(icol,ilay), coeffs_ssa)));
+        real ts = t * (1. - std::max(0., pade_eval(ibnd, nbnd, nsizes, m_ssa, n_ssa, irad, re(icol,ilay), coeffs_ssa)));
 
-        irad = std::min(floor((re(icol,ilay) - re_bounds_asy(2))/re_bounds_asy(3))+2, 3._wp);
+        irad = std::min(floor((re(icol,ilay) - re_bounds_asy(2))/re_bounds_asy(3))+2, 3.);
         taussag(icol,ilay,ibnd) = ts *    pade_eval(ibnd, nbnd, nsizes, m_asy, n_asy, irad, re(icol,ilay), coeffs_asy);
 
         taussa (icol,ilay,ibnd) = ts;

--- a/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.cpp
+++ b/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.cpp
@@ -6,7 +6,7 @@ void sum_byband(int ncol, int nlev, int ngpt, int nbnd, int2d const &bnd_lims, r
   using yakl::fortran::SimpleBounds;
 
   parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlev,ncol) , YAKL_LAMBDA (int ibnd, int ilev, int icol) {
-    real bb_flux_s = 0.0_wp;
+    real bb_flux_s = 0.0;
     for (int igpt=bnd_lims(1,ibnd); igpt<=bnd_lims(2,ibnd); igpt++) {
       bb_flux_s += spectral_flux(icol,ilev,igpt);
     }

--- a/cpp/rrtmgp/mo_gas_concentrations.h
+++ b/cpp/rrtmgp/mo_gas_concentrations.h
@@ -95,7 +95,7 @@ public:
     if (igas == GAS_NOT_IN_LIST) {
       stoprun("GasConcs::set_vmr(): trying to set a gas whose name was not provided at initialization");
     }
-    if (w < 0._wp || w > 1._wp) { stoprun("GasConcs::set_vmr(): concentrations should be >= 0, <= 1"); }
+    if (w < 0. || w > 1.) { stoprun("GasConcs::set_vmr(): concentrations should be >= 0, <= 1"); }
     YAKL_SCOPE( this_concs , this->concs );
     // for (int ilay=1; ilay<=this->nlay; ilay++) {
     //   for (int icol=1; icol<=this->ncol; icol++) {
@@ -122,7 +122,7 @@ public:
       yakl::ScalarLiveOut<bool> badVal(false); // Scalar that must exist in device memory (equiv: bool badVal = false;)
       // for (int i=1; i<=size(w,1); i++) {
       parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(size(w,1)) , YAKL_LAMBDA (int i) {
-        if (w(i) < 0._wp || w(i) > 1._wp) { badVal = true; }
+        if (w(i) < 0. || w(i) > 1.) { badVal = true; }
       });
       if (badVal.hostRead()) { stoprun("GasConcs::set_vmr(): concentrations should be >= 0, <= 1"); }
     #endif
@@ -154,7 +154,7 @@ public:
       // for (int j=1; j<=size(w,2); j++) {
       //   for (int i=1; i<=size(w,1); i++) {
       parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(size(w,2),size(w,1)) , YAKL_LAMBDA (int j, int i) {
-        if (w(i,j) < 0._wp || w(i,j) > 1._wp) { badVal = true;}
+        if (w(i,j) < 0. || w(i,j) > 1.) { badVal = true;}
       });
       if (badVal.hostRead()) { stoprun("GasConcs::set_vmr(): concentrations should be >= 0, <= 1"); }
     #endif

--- a/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
+++ b/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
@@ -959,7 +959,7 @@ public:
     if (allocated(col_dry)) {
       if (size(col_dry,1) != ncol || size(col_dry,2) != nlay) { stoprun("gas_optics(): array col_dry has wrong size"); }
       #ifdef RRTMGP_EXPENSIVE_CHECKS
-        if (any(col_dry < 0._wp)) { stoprun("gas_optics(): array col_dry has values outside range"); }
+        if (any(col_dry < 0.)) { stoprun("gas_optics(): array col_dry has values outside range"); }
       #endif
     }
 
@@ -1105,8 +1105,8 @@ public:
     using yakl::fortran::SimpleBounds;
 
     // first and second term of Helmert formula
-    real constexpr helmert1 = 9.80665_wp;
-    real constexpr helmert2 = 0.02586_wp;
+    real constexpr helmert1 = 9.80665;
+    real constexpr helmert2 = 0.02586;
     int ncol = size(plev,1);
     int nlev = size(plev,2);
     real1d g0("g0",size(plev,1));
@@ -1114,7 +1114,7 @@ public:
       // A purely OpenACC implementation would probably compute g0 within the kernel below
       // do icol = 1, ncol
       parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(ncol) , YAKL_LAMBDA (int icol) {
-        g0(icol) = helmert1 - helmert2 * cos(2.0_wp * M_PI * latitude(icol) / 180.0_wp); // acceleration due to gravity [m/s^2]
+        g0(icol) = helmert1 - helmert2 * cos(2.0 * M_PI * latitude(icol) / 180.0); // acceleration due to gravity [m/s^2]
       });
     } else {
       // do icol = 1, ncol
@@ -1131,9 +1131,9 @@ public:
     parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev-1,ncol) , YAKL_LAMBDA (int ilev , int icol) {
       real delta_plev = abs(plev(icol,ilev) - plev(icol,ilev+1));
       // Get average mass of moist air per mole of moist air
-      real fact = 1._wp / (1.+vmr_h2o(icol,ilev));
+      real fact = 1. / (1.+vmr_h2o(icol,ilev));
       real m_air = (m_dry + m_h2o * vmr_h2o(icol,ilev)) * fact;
-      col_dry(icol,ilev) = 10._wp * delta_plev * avogad * fact/(1000._wp*m_air*100._wp*g0(icol));
+      col_dry(icol,ilev) = 10. * delta_plev * avogad * fact/(1000.*m_air*100.*g0(icol));
     });
     return col_dry;
   }

--- a/cpp/rrtmgp/mo_rrtmgp_constants.cpp
+++ b/cpp/rrtmgp/mo_rrtmgp_constants.cpp
@@ -2,9 +2,9 @@
 #include "mo_rrtmgp_constants.h"
 
 
-real m_dry = 0.028964_wp;
-real grav = 9.80665_wp;
-real cp_dry = 1004.64_wp;
+real m_dry = 0.028964;
+real grav = 9.80665;
+real cp_dry = 1004.64;
 
 
 void init_constants(real gravity, real mol_weight_dry_air, real heat_capacity_dry_air) {

--- a/cpp/rrtmgp/mo_rrtmgp_constants.h
+++ b/cpp/rrtmgp/mo_rrtmgp_constants.h
@@ -7,13 +7,13 @@
 // Physical constants, 2018 SI defintion of metric system
 //   doi:10.1088/1681-7575/aa950a (see also https://www.nist.gov/si-redefinition/meet-constants)
 // Boltzmann constant [J/K] = [(kg m^2)/(K s^2)]
-real constexpr k_boltz = 1.380649e-23_wp;
+real constexpr k_boltz = 1.380649e-23;
 
 //  molecular weight of water [kg/mol]
-real constexpr m_h2o =  0.018016_wp;
+real constexpr m_h2o =  0.018016;
 
 // Avogadro's number [molec/mol]
-real constexpr avogad = 6.02214076e23_wp;
+real constexpr avogad = 6.02214076e23;
 
 // Universal gas constant [J/(mol K)]
 real constexpr R_univ_gconst = avogad * k_boltz;

--- a/cpp/rte/kernels/mo_fluxes_broadband_kernels.cpp
+++ b/cpp/rte/kernels/mo_fluxes_broadband_kernels.cpp
@@ -15,7 +15,7 @@ void sum_broadband(int ncol, int nlev, int ngpt, real3d const &spectral_flux, re
         #pragma omp parallel for
       #endif
       for (int icol = 1; icol <= ncol; icol++) {
-        broadband_flux(icol, ilev) = 0.0_wp;
+        broadband_flux(icol, ilev) = 0.0;
       }
       #ifdef YAKL_ARCH_OPENMP
         #pragma omp parallel for
@@ -33,7 +33,7 @@ void sum_broadband(int ncol, int nlev, int ngpt, real3d const &spectral_flux, re
     // do ilev = 1, nlev
     //   do icol = 1, ncol
     parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev,ncol) , YAKL_LAMBDA (int ilev, int icol) {
-      real bb_flux_s = 0.0_wp;
+      real bb_flux_s = 0.0;
       for (int igpt=1; igpt<=ngpt; igpt++) {
         bb_flux_s += spectral_flux(icol, ilev, igpt);
       }

--- a/cpp/rte/kernels/mo_optical_props_kernels.cpp
+++ b/cpp/rte/kernels/mo_optical_props_kernels.cpp
@@ -91,9 +91,9 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, real3d const &tau, re
     if (tau(icol,ilay,igpt) > eps) {
       real f  = g  (icol,ilay,igpt) * g  (icol,ilay,igpt);
       real wf = ssa(icol,ilay,igpt) * f;
-      tau(icol,ilay,igpt) = (1._wp - wf) * tau(icol,ilay,igpt);
-      ssa(icol,ilay,igpt) = (ssa(icol,ilay,igpt) - wf) / (1.0_wp - wf);
-      g  (icol,ilay,igpt) = (g  (icol,ilay,igpt) -  f) / (1.0_wp -  f);
+      tau(icol,ilay,igpt) = (1. - wf) * tau(icol,ilay,igpt);
+      ssa(icol,ilay,igpt) = (ssa(icol,ilay,igpt) - wf) / (1.0 - wf);
+      g  (icol,ilay,igpt) = (g  (icol,ilay,igpt) -  f) / (1.0 -  f);
     }
   });
 }
@@ -115,9 +115,9 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, real3d const &tau, re
   parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     if (tau(icol,ilay,igpt) > eps) {
       real wf = ssa(icol,ilay,igpt) * f(icol,ilay,igpt);
-      tau(icol,ilay,igpt) = (1._wp - wf) * tau(icol,ilay,igpt);
-      ssa(icol,ilay,igpt) = (ssa(icol,ilay,igpt) - wf) /  (1.0_wp - wf);
-      g  (icol,ilay,igpt) = (g  (icol,ilay,igpt) - f(icol,ilay,igpt)) / (1._wp - f(icol,ilay,igpt));
+      tau(icol,ilay,igpt) = (1. - wf) * tau(icol,ilay,igpt);
+      ssa(icol,ilay,igpt) = (ssa(icol,ilay,igpt) - wf) /  (1.0 - wf);
+      g  (icol,ilay,igpt) = (g  (icol,ilay,igpt) - f(icol,ilay,igpt)) / (1. - f(icol,ilay,igpt));
     }
   });
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
@@ -161,7 +161,7 @@ void increment_1scalar_by_2stream(int ncol, int nlay, int ngpt, real3d const &ta
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
   parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
-    tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt) * (1._wp - ssa2(icol,ilay,igpt));
+    tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt) * (1. - ssa2(icol,ilay,igpt));
   });
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
@@ -177,7 +177,7 @@ void increment_1scalar_by_nstream(int ncol, int nlay, int ngpt, real3d const &ta
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
   parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
-    tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt) * (1._wp - ssa2(icol,ilay,igpt));
+    tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt) * (1. - ssa2(icol,ilay,igpt));
   });
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
@@ -365,7 +365,7 @@ void inc_1scalar_by_2stream_bybnd(int ncol, int nlay, int ngpt, real3d const &ta
   parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     for (int ibnd=1; ibnd<=nbnd; ibnd++) {
       if (igpt >= gpt_lims(1, ibnd) && igpt <= gpt_lims(2, ibnd) ) {
-        tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd) * (1._wp - ssa2(icol,ilay,ibnd));
+        tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd) * (1. - ssa2(icol,ilay,ibnd));
       }
     }
   });
@@ -386,7 +386,7 @@ void inc_1scalar_by_nstream_bybnd(int ncol, int nlay, int ngpt, real3d const &ta
   parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     for (int ibnd=1; ibnd<=nbnd; ibnd++) {
       if (igpt >= gpt_lims(1, ibnd) && igpt <= gpt_lims(2, ibnd) ) {
-        tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd) * (1._wp - ssa2(icol,ilay,ibnd));
+        tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd) * (1. - ssa2(icol,ilay,ibnd));
       }
     }
   });
@@ -591,7 +591,7 @@ void extract_subset_absorption_tau(int ncol, int nlay, int ngpt, real3d const &t
   //   do ilay = 1, nlay
   //     do icol = colS, colE
   parallel_for( YAKL_AUTO_LABEL() , Bounds<3>(ngpt,nlay,{colS,colE}) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
-    tau_out(icol-colS+1, ilay, igpt) = tau_in(icol, ilay, igpt) * (1._wp - ssa_in(icol, ilay, igpt));
+    tau_out(icol-colS+1, ilay, igpt) = tau_in(icol, ilay, igpt) * (1. - ssa_in(icol, ilay, igpt));
   });
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }

--- a/cpp/rte/kernels/mo_rte_solver_kernels.cpp
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.cpp
@@ -99,7 +99,7 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &albedo_sf
       // From bottom to top of atmosphere --
       //   compute albedo and source of upward radiation
       for (ilev=nlay; ilev>=1; ilev--) {
-        denom(icol,ilev,igpt) = 1._wp/(1._wp - rdif(icol,ilev,igpt)*albedo(icol,ilev+1,igpt));    // Eq 10
+        denom(icol,ilev,igpt) = 1./(1. - rdif(icol,ilev,igpt)*albedo(icol,ilev+1,igpt));    // Eq 10
         albedo(icol,ilev,igpt) = rdif(icol,ilev,igpt) + 
                                  tdif(icol,ilev,igpt)*tdif(icol,ilev,igpt) * albedo(icol,ilev+1,igpt) * denom(icol,ilev,igpt); // Equation 9
         // Equation 11 -- source is emitted upward radiation at top of layer plus
@@ -148,7 +148,7 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &albedo_sf
           //   compute albedo and source of upward radiation
         for (ilev = 1; ilev <= nlay; ilev++) {
           for (int icol = 1; icol <= ncol; icol++) {
-            denom (icol,ilev  ,igpt) = 1._wp/(1._wp - rdif(icol,ilev,igpt)*albedo(icol,ilev,igpt));                // Eq 10
+            denom (icol,ilev  ,igpt) = 1./(1. - rdif(icol,ilev,igpt)*albedo(icol,ilev,igpt));                // Eq 10
             albedo(icol,ilev+1,igpt) = rdif(icol,ilev,igpt) + 
                                        tdif(icol,ilev,igpt)*tdif(icol,ilev,igpt) * albedo(icol,ilev,igpt) * denom(icol,ilev,igpt); // Equation 9
             // Equation 11 -- source is emitted upward radiation at top of layer plus
@@ -195,7 +195,7 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &albedo_sf
         // From bottom to top of atmosphere --
         //   compute albedo and source of upward radiation
         for (ilev = 1; ilev <= nlay; ilev++) {
-          denom (icol,ilev  ,igpt) = 1._wp/(1._wp - rdif(icol,ilev,igpt)*albedo(icol,ilev,igpt));                // Eq 10
+          denom (icol,ilev  ,igpt) = 1./(1. - rdif(icol,ilev,igpt)*albedo(icol,ilev,igpt));                // Eq 10
           albedo(icol,ilev+1,igpt) = rdif(icol,ilev,igpt) + 
                                      tdif(icol,ilev,igpt)*tdif(icol,ilev,igpt) * albedo(icol,ilev,igpt) * denom(icol,ilev,igpt); // Equation 9
           // Equation 11 -- source is emitted upward radiation at top of layer plus
@@ -313,10 +313,10 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, real2d const 
   parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
     // Transport is for intensity
     //   convert flux at top of domain to intensity assuming azimuthal isotropy
-    radn_dn(icol,top_level,igpt) = radn_dn(icol,top_level,igpt)/(2._wp * pi * weights(weight_ind));
+    radn_dn(icol,top_level,igpt) = radn_dn(icol,top_level,igpt)/(2. * pi * weights(weight_ind));
     
     // Surface albedo, surface source function
-    sfc_albedo(icol,igpt) = 1._wp - sfc_emis(icol,igpt);
+    sfc_albedo(icol,igpt) = 1. - sfc_emis(icol,igpt);
     source_sfc(icol,igpt) = sfc_emis(icol,igpt) * sfc_src(icol,igpt);
   });
 
@@ -346,8 +346,8 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, real2d const 
   //   do ilev = 1, nlay+1
   //     do icol = 1, ncol
   parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay+1,ncol) , YAKL_LAMBDA (int igpt, int ilev, int icol) {
-    radn_dn(icol,ilev,igpt) = 2._wp * pi * weights(weight_ind) * radn_dn(icol,ilev,igpt);
-    radn_up(icol,ilev,igpt) = 2._wp * pi * weights(weight_ind) * radn_up(icol,ilev,igpt);
+    radn_dn(icol,ilev,igpt) = 2. * pi * weights(weight_ind) * radn_dn(icol,ilev,igpt);
+    radn_up(icol,ilev,igpt) = 2. * pi * weights(weight_ind) * radn_up(icol,ilev,igpt);
   });
 }
 
@@ -432,7 +432,7 @@ void lw_source_2str(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &s
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
   parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
-    if ( tau(icol,ilay,ngpt) > 1.0e-8_wp ) {
+    if ( tau(icol,ilay,ngpt) > 1.0e-8 ) {
       real lev_source_top, lev_source_bot;
       if (top_at_1) {
         lev_source_top = lev_source(icol,ilay  ,ngpt);
@@ -450,8 +450,8 @@ void lw_source_2str(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &s
       source_up(icol,ilay,igpt) = pi * (Zup_top    - rdif(icol,ilay,igpt) * Zdn_top    - tdif(icol,ilay,igpt) * Zup_bottom);
       source_dn(icol,ilay,igpt) = pi * (Zdn_bottom - rdif(icol,ilay,igpt) * Zup_bottom - tdif(icol,ilay,igpt) * Zdn_top);
     } else {
-      source_up(icol,ilay,igpt) = 0._wp;
-      source_dn(icol,ilay,igpt) = 0._wp;
+      source_up(icol,ilay,igpt) = 0.;
+      source_dn(icol,ilay,igpt) = 0.;
     }
     if(ilay == 1) {
       source_sfc(icol,igpt) = pi * sfc_emis(icol,igpt) * sfc_src(icol,igpt);
@@ -507,8 +507,8 @@ void lw_two_stream(int ncol, int nlay, int ngpt, real3d const &tau, real3d const
     // Coefficients differ from SW implementation because the phase function is more isotropic
     //   Here we follow Fu et al. 1997, doi:10.1175/1520-0469(1997)054<2799:MSPITI>2.0.CO;2
     //   and use a diffusivity sec of 1.66
-    gamma1(icol,ilay,igpt)= LW_diff_sec * (1._wp - 0.5_wp * w0(icol,ilay,igpt) * (1._wp + g(icol,ilay,igpt))); // Fu et al. Eq 2.9
-    gamma2(icol,ilay,igpt)= LW_diff_sec *          0.5_wp * w0(icol,ilay,igpt) * (1._wp - g(icol,ilay,igpt));  // Fu et al. Eq 2.10
+    gamma1(icol,ilay,igpt)= LW_diff_sec * (1. - 0.5 * w0(icol,ilay,igpt) * (1. + g(icol,ilay,igpt))); // Fu et al. Eq 2.9
+    gamma2(icol,ilay,igpt)= LW_diff_sec *          0.5 * w0(icol,ilay,igpt) * (1. - g(icol,ilay,igpt));  // Fu et al. Eq 2.10
 
     // Written to encourage vectorization of exponential, square root
     // Eq 18;  k = SQRT(gamma1**2 - gamma2**2), limited below to avoid div by 0.
@@ -516,20 +516,20 @@ void lw_two_stream(int ncol, int nlay, int ngpt, real3d const &tau, real3d const
     //   gives relative error with respect to conservative solution
     //   of < 0.1% in Rdif down to tau = 10^-9
     real k = sqrt(std::max((gamma1(icol,ilay,igpt) - gamma2(icol,ilay,igpt)) * 
-                           (gamma1(icol,ilay,igpt) + gamma2(icol,ilay,igpt)) , 1.e-12_wp));
+                           (gamma1(icol,ilay,igpt) + gamma2(icol,ilay,igpt)) , 1.e-12));
     real exp_minusktau = exp(-tau(icol,ilay,igpt)*k);
 
     // Diffuse reflection and transmission
     real exp_minus2ktau = exp_minusktau * exp_minusktau;
 
     // Refactored to avoid rounding errors when k, gamma1 are of very different magnitudes
-    real RT_term = 1._wp / (k * (1._wp + exp_minus2ktau)  +  gamma1(icol,ilay,igpt) * (1._wp - exp_minus2ktau) );
+    real RT_term = 1. / (k * (1. + exp_minus2ktau)  +  gamma1(icol,ilay,igpt) * (1. - exp_minus2ktau) );
 
     // Equation 25
-    Rdif(icol,ilay,igpt) = RT_term * gamma2(icol,ilay,igpt) * (1._wp - exp_minus2ktau);
+    Rdif(icol,ilay,igpt) = RT_term * gamma2(icol,ilay,igpt) * (1. - exp_minus2ktau);
 
     // Equation 26
-    Tdif(icol,ilay,igpt) = RT_term * 2._wp * k * exp_minusktau;
+    Tdif(icol,ilay,igpt) = RT_term * 2. * k * exp_minusktau;
   });
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
@@ -546,7 +546,7 @@ void sw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, real3d const 
   real1d mu0_inv("mu0_inv",ncol);
 
   parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA (int icol) {
-    mu0_inv(icol) = 1._wp/mu0(icol);
+    mu0_inv(icol) = 1./mu0(icol);
   });
 
   // Indexing into arrays for upward and downward propagation depends on the vertical
@@ -624,7 +624,7 @@ void lw_solver_2stream(int ncol, int nlay, int ngpt, bool top_at_1, real3d const
   // do igpt = 1, ngpt
   //   do icol = 1, ncol
   parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
-    sfc_albedo(icol,igpt) = 1._wp - sfc_emis(icol,igpt);
+    sfc_albedo(icol,igpt) = 1. - sfc_emis(icol,igpt);
   });
 
   // Transport

--- a/cpp/rte/mo_optical_props.h
+++ b/cpp/rte/mo_optical_props.h
@@ -30,7 +30,7 @@ public:
     int2d band_lims_gpt_lcl("band_lims_gpt_lcl",2,size(band_lims_wvn,2));
     if (size(band_lims_wvn,1) != 2) { stoprun("optical_props::init(): band_lims_wvn 1st dim should be 2"); }
     #ifdef RRTMGP_EXPENSIVE_CHECKS
-      if (any(band_lims_wvn < 0._wp)) { stoprun("optical_props::init(): band_lims_wvn has values <  0."); }
+      if (any(band_lims_wvn < 0.)) { stoprun("optical_props::init(): band_lims_wvn has values <  0."); }
     #endif
     if (allocated(band_lims_gpt)) {
       if (size(band_lims_gpt,2) != size(band_lims_wvn,2)) {
@@ -155,11 +155,11 @@ public:
     YAKL_SCOPE( this_band_lims_wvn , this->band_lims_wvn );
     if (this->is_initialized()) {
       parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>( size(band_lims_wvn,2) , size(band_lims_wvn,1) ) , YAKL_LAMBDA (int j, int i) {
-        ret(i,j) = 1._wp / this_band_lims_wvn(i,j);
+        ret(i,j) = 1. / this_band_lims_wvn(i,j);
       });
     } else {
       parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>( size(band_lims_wvn,2) , size(band_lims_wvn,1) ) , YAKL_LAMBDA (int j, int i) {
-        ret(i,j) = 0._wp;
+        ret(i,j) = 0.;
       });
     }
     return ret;

--- a/cpp/rte/mo_rte_lw.h
+++ b/cpp/rte/mo_rte_lw.h
@@ -84,14 +84,14 @@ void rte_lw(int max_gauss_pts, real2d const &gauss_Ds, real2d const &gauss_wts, 
   // Surface emissivity
   if (size(sfc_emis,1) != nband || size(sfc_emis,2) != ncol) { stoprun("rte_lw: sfc_emis inconsistently sized"); }
   #ifdef RRTMGP_EXPENSIVE_CHECKS
-    if (any(sfc_emis < 0._wp) || any(sfc_emis > 1._wp)) { stoprun("rte_lw: sfc_emis has values < 0 or > 1"); }
+    if (any(sfc_emis < 0.) || any(sfc_emis > 1.)) { stoprun("rte_lw: sfc_emis has values < 0 or > 1"); }
   #endif
 
   // Incident flux, if present
   if (allocated(inc_flux)) {
     if (size(inc_flux,1) != ncol | size(inc_flux,2) != ngpt) { stoprun("rte_lw: inc_flux inconsistently sized"); }
     #ifdef RRTMGP_EXPENSIVE_CHECKS
-      if (any(inc_flux < 0._wp)) { stoprun("rte_lw: inc_flux has values < 0"); }
+      if (any(inc_flux < 0.)) { stoprun("rte_lw: inc_flux has values < 0"); }
     #endif
   }
 

--- a/cpp/rte/mo_rte_sw.h
+++ b/cpp/rte/mo_rte_sw.h
@@ -65,27 +65,27 @@ void rte_sw(OpticalProps2str const &atmos, bool top_at_1, real1d const &mu0, rea
 
   if (size(mu0,1) != ncol) { stoprun("rte_sw: mu0 inconsistently sized"); }
   #ifdef RRTMGP_EXPENSIVE_CHECKS
-    if (any(mu0 < 0._wp) || any(mu0 > 1._wp)) { stoprun("rte_sw: one or more mu0 <= 0 or > 1"); }
+    if (any(mu0 < 0.) || any(mu0 > 1.)) { stoprun("rte_sw: one or more mu0 <= 0 or > 1"); }
   #endif
 
   if (size(inc_flux,1) != ncol || size(inc_flux,2) != ngpt) { stoprun("rte_sw: inc_flux inconsistently sized"); }
   #ifdef RRTMGP_EXPENSIVE_CHECKS
-    if (any(inc_flux < 0._wp)) { stoprun("rte_sw: one or more inc_flux < 0"); }
+    if (any(inc_flux < 0.)) { stoprun("rte_sw: one or more inc_flux < 0"); }
   #endif
   if (allocated(inc_flux_dif)) {
     if (size(inc_flux_dif,1) != ncol || size(inc_flux_dif,2) != ngpt) { stoprun("rte_sw: inc_flux_dif inconsistently sized"); }
     #ifdef RRTMGP_EXPENSIVE_CHECKS
-      if (any(inc_flux_dif < 0._wp)) { stoprun("rte_sw: one or more inc_flux_dif < 0"); }
+      if (any(inc_flux_dif < 0.)) { stoprun("rte_sw: one or more inc_flux_dif < 0"); }
     #endif
   }
 
   if (size(sfc_alb_dir,1) != nband || size(sfc_alb_dir,2) != ncol) { stoprun("rte_sw: sfc_alb_dir inconsistently sized"); }
   #ifdef RRTMGP_EXPENSIVE_CHECKS
-    if (any(sfc_alb_dir < 0._wp) || any(sfc_alb_dir > 1._wp)) { stoprun("rte_sw: sfc_alb_dir out of bounds [0,1]"); }
+    if (any(sfc_alb_dir < 0.) || any(sfc_alb_dir > 1.)) { stoprun("rte_sw: sfc_alb_dir out of bounds [0,1]"); }
   #endif
   if (size(sfc_alb_dif,1) != nband || size(sfc_alb_dif,2) != ncol) { stoprun("rte_sw: sfc_alb_dif inconsistently sized"); }
   #ifdef RRTMGP_EXPENSIVE_CHECKS
-    if (any(sfc_alb_dif < 0._wp) || any(sfc_alb_dif > 1._wp)) { stoprun("rte_sw: sfc_alb_dif out of bounds [0,1]"); }
+    if (any(sfc_alb_dif < 0.) || any(sfc_alb_dif > 1.)) { stoprun("rte_sw: sfc_alb_dif out of bounds [0,1]"); }
   #endif
 
   gpt_flux_up  = real3d("gpt_flux_up" ,ncol, nlay+1, ngpt);


### PR DESCRIPTION
This PR removes the double float literals in c++ code, which is not supported in the c++ sycl gpu code. This is the issue we have discussed and decided to remove the double float literals long time ago, since we are using by default the double precission in our c++ cpu and gpu code.