### PR TITLE
Use pool allocator for Kokkos temp work views

### DIFF
--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -362,13 +362,13 @@ int main(int argc , char **argv) {
 #endif
       }
 
-#ifdef RRTMGP_ENABLE_KOKKOS
-      conv::MemPoolSingleton::finalize();
-#endif
-
       auto stop_t = std::chrono::high_resolution_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t);
       std::cout << "Shortwave did " << nloops << " loops of " << ncol << " cols and " << nlay << " layers in " <<  duration.count() / 1000000.0 << " s" << std::endl;
+
+#ifdef RRTMGP_ENABLE_KOKKOS
+      conv::MemPoolSingleton::finalize();
+#endif
 
       if (verbose) std::cout << "Writing fluxes\n\n";
 #ifdef RRTMGP_ENABLE_YAKL
@@ -576,11 +576,13 @@ int main(int argc , char **argv) {
 #endif
 
 #ifdef RRTMGP_ENABLE_KOKKOS
-      // const size_t MinBlockSize   = 32768;
-      // const size_t MaxBlockSize   = 1048576;
-      // const size_t SuperBlockSize = 1048576;
-      // conv::MemPoolSingleton::init(10000000, MinBlockSize, MaxBlockSize, SuperBlockSize,
-      //                              10000000, MinBlockSize, MaxBlockSize, SuperBlockSize);
+      const size_t MaxBlockSize   = 528640000;
+      const size_t MinBlockSize   = MaxBlockSize / 20;
+      const size_t SuperBlockSize = MaxBlockSize;
+      const size_t Capacity       = 4e9;
+      conv::MemPoolSingleton::init(Capacity, MinBlockSize, MaxBlockSize, SuperBlockSize,
+                                   Capacity, MinBlockSize, MaxBlockSize, SuperBlockSize);
+      conv::MemPoolSingleton::print_state();
       realOff3dk col_gas  ("col_gas"     ,std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
 #endif
 
@@ -658,6 +660,10 @@ int main(int argc , char **argv) {
       auto stop_t = std::chrono::high_resolution_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t);
       std::cout << "Longwave did " << nloops << " loops of " << ncol << " cols and " << nlay << " layers in " <<  duration.count() / 1000000.0 << " s" << std::endl;
+
+#ifdef RRTMGP_ENABLE_KOKKOS
+      conv::MemPoolSingleton::finalize();
+#endif
 
       if (verbose) std::cout << "Writing fluxes\n\n";
 #ifdef RRTMGP_ENABLE_YAKL

--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -45,7 +45,7 @@ int main(int argc , char **argv) {
     std::string input_file        =      argv[1];
     std::string k_dist_file       =      argv[2];
     std::string cloud_optics_file =      argv[3];
-    int ncol                      = std::atoi(argv[4]);
+    const int ncol                = std::atoi(argv[4]);
     int nloops = 1;
     if (argc >= 6) { nloops       = std::atoi(argv[5]); }
     if (ncol   <= 0) { stoprun("Error: Number of columns must be > 0"); }
@@ -95,7 +95,8 @@ int main(int argc , char **argv) {
     VALIDATE_KOKKOS(gas_concs, gas_concs_k);
 #endif
 
-    int nlay = COMPUTE_SWITCH(size(p_lay,2), p_lay_k.extent(1));
+    const int nlay = COMPUTE_SWITCH(size(p_lay,2), p_lay_k.extent(1));
+    const int nlev = COMPUTE_SWITCH(size(p_lev,2), p_lev_k.extent(1));
 
     // load data into classes
     if (verbose) std::cout << "Reading k_dist file\n\n";
@@ -270,7 +271,9 @@ int main(int argc , char **argv) {
 #endif
 
 #ifdef RRTMGP_ENABLE_KOKKOS
-      conv::MemPoolSingleton::init(2e6);
+      const size_t base_ref = 18000;
+      const size_t my_size_ref = ncol * nlay * nlev;
+      conv::MemPoolSingleton::init(2e6 * (float(my_size_ref) / base_ref));
       realOff3dk col_gas("col_gas", std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
 #endif
 
@@ -570,7 +573,9 @@ int main(int argc , char **argv) {
 #endif
 
 #ifdef RRTMGP_ENABLE_KOKKOS
-      conv::MemPoolSingleton::init(2e6);
+      const size_t base_ref = 18000;
+      const size_t my_size_ref = ncol * nlay * nlev;
+      conv::MemPoolSingleton::init(2e6 * (float(my_size_ref) / base_ref));
       realOff3dk col_gas("col_gas", std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
 #endif
 

--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -270,12 +270,14 @@ int main(int argc , char **argv) {
 #endif
 
 #ifdef RRTMGP_ENABLE_KOKKOS
-      const size_t MinBlockSize   = 1024;
-      const size_t MaxBlockSize   = 10485760;
-      const size_t SuperBlockSize = 10485760;
-      conv::MemPoolSingleton::init(200000000, MinBlockSize, MaxBlockSize, SuperBlockSize,
-                                   200000000, MinBlockSize, MaxBlockSize, SuperBlockSize);
-      realOff3dk col_gas  ("col_gas"     ,std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist.get_ngas()-1));
+      const size_t MaxBlockSize   = 528640000;
+      const size_t MinBlockSize   = MaxBlockSize / 20;
+      const size_t SuperBlockSize = MaxBlockSize;
+      const size_t Capacity       = 4e9;
+      conv::MemPoolSingleton::init(Capacity, MinBlockSize, MaxBlockSize, SuperBlockSize,
+                                   Capacity, MinBlockSize, MaxBlockSize, SuperBlockSize);
+      conv::MemPoolSingleton::print_state();
+      realOff3dk col_gas  ("col_gas"     ,std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
 #endif
 
       if (verbose) std::cout << "Running the main loop\n\n";
@@ -579,7 +581,7 @@ int main(int argc , char **argv) {
       // const size_t SuperBlockSize = 1048576;
       // conv::MemPoolSingleton::init(10000000, MinBlockSize, MaxBlockSize, SuperBlockSize,
       //                              10000000, MinBlockSize, MaxBlockSize, SuperBlockSize);
-      realOff3dk col_gas  ("col_gas"     ,std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist.get_ngas()-1));
+      realOff3dk col_gas  ("col_gas"     ,std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
 #endif
 
       // Multiple iterations for big problem sizes, and to help identify data movement

--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -270,7 +270,7 @@ int main(int argc , char **argv) {
 #endif
 
 #ifdef RRTMGP_ENABLE_KOKKOS
-      conv::MemPoolSingleton::init(1e6);
+      conv::MemPoolSingleton::init(2e6);
       realOff3dk col_gas("col_gas", std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
 #endif
 
@@ -570,7 +570,7 @@ int main(int argc , char **argv) {
 #endif
 
 #ifdef RRTMGP_ENABLE_KOKKOS
-      conv::MemPoolSingleton::init(1e6);
+      conv::MemPoolSingleton::init(2e6);
       realOff3dk col_gas("col_gas", std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
 #endif
 

--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -272,6 +272,14 @@ int main(int argc , char **argv) {
       if (verbose) std::cout << "Running the main loop\n\n";
       auto start_t = std::chrono::high_resolution_clock::now();
 
+#ifdef RRTMGP_ENABLE_KOKKOS
+      const size_t MinBlockSize   = 64;
+      const size_t MaxBlockSize   = 1024;
+      const size_t SuperBlockSize = 4096;
+      conv::MemPoolSingleton::init(10000, MinBlockSize, MaxBlockSize, SuperBlockSize,
+                                   10000, MinBlockSize, MaxBlockSize, SuperBlockSize);
+      ureal1dk my_u_view(conv::MemPoolSingleton::alloc_host<real>(100), 100);
+#endif
       for (int iloop = 1 ; iloop <= nloops ; iloop++) {
 
 #ifdef RRTMGP_ENABLE_YAKL
@@ -350,6 +358,11 @@ int main(int argc , char **argv) {
         if (print_norms) fluxes_k.print_norms();
 #endif
       }
+
+#ifdef RRTMGP_ENABLE_KOKKOS
+      conv::MemPoolSingleton::finalize();
+#endif
+
 
       auto stop_t = std::chrono::high_resolution_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t);

--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -270,14 +270,8 @@ int main(int argc , char **argv) {
 #endif
 
 #ifdef RRTMGP_ENABLE_KOKKOS
-      const size_t MaxBlockSize   = 528640000;
-      const size_t MinBlockSize   = MaxBlockSize / 20;
-      const size_t SuperBlockSize = MaxBlockSize;
-      const size_t Capacity       = 4e9;
-      conv::MemPoolSingleton::init(Capacity, MinBlockSize, MaxBlockSize, SuperBlockSize,
-                                   Capacity, MinBlockSize, MaxBlockSize, SuperBlockSize);
-      conv::MemPoolSingleton::print_state();
-      realOff3dk col_gas  ("col_gas"     ,std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
+      conv::MemPoolSingleton::init(1e6);
+      realOff3dk col_gas("col_gas", std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
 #endif
 
       if (verbose) std::cout << "Running the main loop\n\n";
@@ -576,14 +570,8 @@ int main(int argc , char **argv) {
 #endif
 
 #ifdef RRTMGP_ENABLE_KOKKOS
-      const size_t MaxBlockSize   = 528640000;
-      const size_t MinBlockSize   = MaxBlockSize / 20;
-      const size_t SuperBlockSize = MaxBlockSize;
-      const size_t Capacity       = 4e9;
-      conv::MemPoolSingleton::init(Capacity, MinBlockSize, MaxBlockSize, SuperBlockSize,
-                                   Capacity, MinBlockSize, MaxBlockSize, SuperBlockSize);
-      conv::MemPoolSingleton::print_state();
-      realOff3dk col_gas  ("col_gas"     ,std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
+      conv::MemPoolSingleton::init(1e6);
+      realOff3dk col_gas("col_gas", std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
 #endif
 
       // Multiple iterations for big problem sizes, and to help identify data movement

--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -270,9 +270,9 @@ int main(int argc , char **argv) {
 #endif
 
 #ifdef RRTMGP_ENABLE_KOKKOS
-      const size_t MinBlockSize   = 32768;
+      const size_t MinBlockSize   = 1024;
       const size_t MaxBlockSize   = 10485760;
-      const size_t SuperBlockSize = 104857600;
+      const size_t SuperBlockSize = 10485760;
       conv::MemPoolSingleton::init(200000000, MinBlockSize, MaxBlockSize, SuperBlockSize,
                                    200000000, MinBlockSize, MaxBlockSize, SuperBlockSize);
       realOff3dk col_gas  ("col_gas"     ,std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist.get_ngas()-1));
@@ -363,7 +363,6 @@ int main(int argc , char **argv) {
 #ifdef RRTMGP_ENABLE_KOKKOS
       conv::MemPoolSingleton::finalize();
 #endif
-
 
       auto stop_t = std::chrono::high_resolution_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t);

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -760,9 +760,9 @@ public:
     if (! (this->lut_extliq.is_allocated() || this->pade_extliq.is_allocated())) { stoprun("cloud optics: no data has been initialized"); }
     // Array sizes
     const int num_bools = ncol * nlay;
-    bool* bdata         = pool::alloc<bool>(num_bools * 2);
-    bool2dk liqmsk(bdata,             ncol, nlay);
-    bool2dk icemsk(bdata + num_bools, ncol, nlay);
+    bool* bdata         = pool::alloc<bool>(num_bools * 2), *bcurr = bdata;
+    bool2dk liqmsk(bcurr, ncol, nlay); bcurr += num_bools;
+    bool2dk icemsk(bcurr, ncol, nlay); bcurr += num_bools;
 
     // Spectral consistency
     if (! this->bands_are_equal(optical_props)) { stoprun("cloud optics: optical properties don't have the same band structure"); }
@@ -799,13 +799,13 @@ public:
     // We could compute the properties for liquid and ice separately and
     //    use ty_optical_props_arry.increment but this involves substantially more division.
     const int num_tau = clwp.extent(0) *  clwp.extent(1) * this->get_nband();
-    real* data        = pool::alloc<real>(num_tau * 6);
-    real3dk ltau    (data,             clwp.extent(0), clwp.extent(1), this->get_nband());
-    real3dk ltaussa (data + num_tau,   clwp.extent(0), clwp.extent(1), this->get_nband());
-    real3dk ltaussag(data + num_tau*2, clwp.extent(0), clwp.extent(1), this->get_nband());
-    real3dk itau    (data + num_tau*3, clwp.extent(0), clwp.extent(1), this->get_nband());
-    real3dk itaussa (data + num_tau*4, clwp.extent(0), clwp.extent(1), this->get_nband());
-    real3dk itaussag(data + num_tau*5, clwp.extent(0), clwp.extent(1), this->get_nband());
+    real* data        = pool::alloc<real>(num_tau * 6), *dcurr = data;
+    real3dk ltau    (dcurr, clwp.extent(0), clwp.extent(1), this->get_nband()); dcurr += num_tau;
+    real3dk ltaussa (dcurr, clwp.extent(0), clwp.extent(1), this->get_nband()); dcurr += num_tau;
+    real3dk ltaussag(dcurr, clwp.extent(0), clwp.extent(1), this->get_nband()); dcurr += num_tau;
+    real3dk itau    (dcurr, clwp.extent(0), clwp.extent(1), this->get_nband()); dcurr += num_tau;
+    real3dk itaussa (dcurr, clwp.extent(0), clwp.extent(1), this->get_nband()); dcurr += num_tau;
+    real3dk itaussag(dcurr, clwp.extent(0), clwp.extent(1), this->get_nband()); dcurr += num_tau;
     if (this->lut_extliq.is_allocated()) {
       // Liquid
       compute_all_from_table(ncol, nlay, nbnd, liqmsk, clwp, reliq, this->liq_nsteps,this->liq_step_size,this->radliq_lwr,
@@ -836,8 +836,8 @@ public:
     //   See also the increment routines in mo_optical_props_kernels
     combine( nbnd, nlay, ncol, ltau, itau, ltaussa, itaussa, ltaussag, itaussag, optical_props );
 
-    pool::dealloc(bdata, 2 * num_bools);
-    pool::dealloc(data , 6 * num_tau);
+    pool::dealloc(bdata, bcurr - bdata);
+    pool::dealloc(data , dcurr - data);
   }
 
   void combine( int nbnd, int nlay, int ncol, real3dk const &ltau, real3dk const &itau, real3dk const &ltaussa, real3dk const &itaussa,

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -753,13 +753,16 @@ public:
   // Compute single-scattering properties
   template <class T>  // T is a template for a child class of OpticalPropsArry
   void cloud_optics(const int ncol, const int nlay, real2dk const &clwp, real2dk const &ciwp, real2dk const &reliq, real2dk const &reice, T &optical_props) {
+    using pool = conv::MemPoolSingleton;
 
     int nbnd = this->get_nband();
     // Error checking
     if (! (this->lut_extliq.is_allocated() || this->pade_extliq.is_allocated())) { stoprun("cloud optics: no data has been initialized"); }
     // Array sizes
-    bool2dk liqmsk("liqmsk",ncol, nlay);
-    bool2dk icemsk("icemsk",ncol, nlay);
+    const int num_bools = ncol * nlay;
+    bool* bdata         = pool::alloc<bool>(num_bools * 2);
+    ubool2dk liqmsk(bdata,             ncol, nlay);
+    ubool2dk icemsk(bdata + num_bools, ncol, nlay);
 
     // Spectral consistency
     if (! this->bands_are_equal(optical_props)) { stoprun("cloud optics: optical properties don't have the same band structure"); }
@@ -795,12 +798,14 @@ public:
     // These are used to determine the optical properties of ice and water cloud together.
     // We could compute the properties for liquid and ice separately and
     //    use ty_optical_props_arry.increment but this involves substantially more division.
-    real3dk ltau    ("ltau    ",clwp.extent(0), clwp.extent(1), this->get_nband());
-    real3dk ltaussa ("ltaussa ",clwp.extent(0), clwp.extent(1), this->get_nband());
-    real3dk ltaussag("ltaussag",clwp.extent(0), clwp.extent(1), this->get_nband());
-    real3dk itau    ("itau    ",clwp.extent(0), clwp.extent(1), this->get_nband());
-    real3dk itaussa ("itaussa ",clwp.extent(0), clwp.extent(1), this->get_nband());
-    real3dk itaussag("itaussag",clwp.extent(0), clwp.extent(1), this->get_nband());
+    const int num_tau = clwp.extent(0) *  clwp.extent(1) * this->get_nband();
+    real* data        = pool::alloc<real>(num_tau * 6);
+    ureal3dk ltau    (data,             clwp.extent(0), clwp.extent(1), this->get_nband());
+    ureal3dk ltaussa (data + num_tau,   clwp.extent(0), clwp.extent(1), this->get_nband());
+    ureal3dk ltaussag(data + num_tau*2, clwp.extent(0), clwp.extent(1), this->get_nband());
+    ureal3dk itau    (data + num_tau*3, clwp.extent(0), clwp.extent(1), this->get_nband());
+    ureal3dk itaussa (data + num_tau*4, clwp.extent(0), clwp.extent(1), this->get_nband());
+    ureal3dk itaussag(data + num_tau*5, clwp.extent(0), clwp.extent(1), this->get_nband());
     if (this->lut_extliq.is_allocated()) {
       // Liquid
       compute_all_from_table(ncol, nlay, nbnd, liqmsk, clwp, reliq, this->liq_nsteps,this->liq_step_size,this->radliq_lwr,
@@ -830,6 +835,9 @@ public:
     // Combine liquid and ice contributions into total cloud optical properties
     //   See also the increment routines in mo_optical_props_kernels
     combine( nbnd, nlay, ncol, ltau, itau, ltaussa, itaussa, ltaussag, itaussag, optical_props );
+
+    pool::dealloc(bdata, 2 * num_bools);
+    pool::dealloc(data , 6 * num_tau);
   }
 
   void combine( int nbnd, int nlay, int ncol, real3dk const &ltau, real3dk const &itau, real3dk const &ltaussa, real3dk const &itaussa,
@@ -890,7 +898,7 @@ public:
   // We could also try gather/scatter for efficiency
   void compute_all_from_table(int ncol, int nlay, int nbnd, bool2dk const &mask, real2dk const &lwp, real2dk const &re,
                               int nsteps, real step_size, real offset, real2dk const &tau_table, real2dk const &ssa_table,
-                              real2dk const &asy_table, real3dk &tau, real3dk &taussa, real3dk &taussag) {
+                              real2dk const &asy_table, ureal3dk &tau, ureal3dk &taussa, ureal3dk &taussag) {
     // do ibnd = 1, nbnd
     //   do ilay = 1,nlay
     //     do icol = 1, ncol
@@ -916,7 +924,7 @@ public:
                              int m_ext, int n_ext, real1dk const &re_bounds_ext, real3dk const &coeffs_ext,
                              int m_ssa, int n_ssa, real1dk const &re_bounds_ssa, real3dk const &coeffs_ssa,
                              int m_asy, int n_asy, real1dk const &re_bounds_asy, real3dk const &coeffs_asy,
-                             real3dk &tau, real3dk &taussa, real3dk &taussag) {
+                             ureal3dk &tau, ureal3dk &taussa, ureal3dk &taussag) {
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1, ncol

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -896,9 +896,11 @@ public:
   //   elements starting at "offset." The table's second dimension is band.
   // Returns 0 where the mask is false.
   // We could also try gather/scatter for efficiency
+  template <typename StrideView>
   void compute_all_from_table(int ncol, int nlay, int nbnd, bool2dk const &mask, real2dk const &lwp, real2dk const &re,
-                              int nsteps, real step_size, real offset, real2dk const &tau_table, real2dk const &ssa_table,
-                              real2dk const &asy_table, real3dk &tau, real3dk &taussa, real3dk &taussag) {
+                              int nsteps, real step_size, real offset,
+                              StrideView const &tau_table, StrideView const &ssa_table, StrideView const &asy_table,
+                              real3dk &tau, real3dk &taussa, real3dk &taussag) {
     // do ibnd = 1, nbnd
     //   do ilay = 1,nlay
     //     do icol = 1, ncol
@@ -920,10 +922,11 @@ public:
   }
 
   // Pade functions
+  template <typename StrideView>
   void compute_all_from_pade(int ncol, int nlay, int nbnd, int nsizes, bool2dk const &mask, real2dk const &lwp, real2dk const &re,
-                             int m_ext, int n_ext, real1dk const &re_bounds_ext, real3dk const &coeffs_ext,
-                             int m_ssa, int n_ssa, real1dk const &re_bounds_ssa, real3dk const &coeffs_ssa,
-                             int m_asy, int n_asy, real1dk const &re_bounds_asy, real3dk const &coeffs_asy,
+                             int m_ext, int n_ext, real1dk const &re_bounds_ext, StrideView const &coeffs_ext,
+                             int m_ssa, int n_ssa, real1dk const &re_bounds_ssa, StrideView const &coeffs_ssa,
+                             int m_asy, int n_asy, real1dk const &re_bounds_asy, StrideView const &coeffs_asy,
                              real3dk &tau, real3dk &taussa, real3dk &taussag) {
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -761,8 +761,8 @@ public:
     // Array sizes
     const int num_bools = ncol * nlay;
     bool* bdata         = pool::alloc<bool>(num_bools * 2);
-    ubool2dk liqmsk(bdata,             ncol, nlay);
-    ubool2dk icemsk(bdata + num_bools, ncol, nlay);
+    bool2dk liqmsk(bdata,             ncol, nlay);
+    bool2dk icemsk(bdata + num_bools, ncol, nlay);
 
     // Spectral consistency
     if (! this->bands_are_equal(optical_props)) { stoprun("cloud optics: optical properties don't have the same band structure"); }
@@ -800,12 +800,12 @@ public:
     //    use ty_optical_props_arry.increment but this involves substantially more division.
     const int num_tau = clwp.extent(0) *  clwp.extent(1) * this->get_nband();
     real* data        = pool::alloc<real>(num_tau * 6);
-    ureal3dk ltau    (data,             clwp.extent(0), clwp.extent(1), this->get_nband());
-    ureal3dk ltaussa (data + num_tau,   clwp.extent(0), clwp.extent(1), this->get_nband());
-    ureal3dk ltaussag(data + num_tau*2, clwp.extent(0), clwp.extent(1), this->get_nband());
-    ureal3dk itau    (data + num_tau*3, clwp.extent(0), clwp.extent(1), this->get_nband());
-    ureal3dk itaussa (data + num_tau*4, clwp.extent(0), clwp.extent(1), this->get_nband());
-    ureal3dk itaussag(data + num_tau*5, clwp.extent(0), clwp.extent(1), this->get_nband());
+    real3dk ltau    (data,             clwp.extent(0), clwp.extent(1), this->get_nband());
+    real3dk ltaussa (data + num_tau,   clwp.extent(0), clwp.extent(1), this->get_nband());
+    real3dk ltaussag(data + num_tau*2, clwp.extent(0), clwp.extent(1), this->get_nband());
+    real3dk itau    (data + num_tau*3, clwp.extent(0), clwp.extent(1), this->get_nband());
+    real3dk itaussa (data + num_tau*4, clwp.extent(0), clwp.extent(1), this->get_nband());
+    real3dk itaussag(data + num_tau*5, clwp.extent(0), clwp.extent(1), this->get_nband());
     if (this->lut_extliq.is_allocated()) {
       // Liquid
       compute_all_from_table(ncol, nlay, nbnd, liqmsk, clwp, reliq, this->liq_nsteps,this->liq_step_size,this->radliq_lwr,
@@ -898,7 +898,7 @@ public:
   // We could also try gather/scatter for efficiency
   void compute_all_from_table(int ncol, int nlay, int nbnd, bool2dk const &mask, real2dk const &lwp, real2dk const &re,
                               int nsteps, real step_size, real offset, real2dk const &tau_table, real2dk const &ssa_table,
-                              real2dk const &asy_table, ureal3dk &tau, ureal3dk &taussa, ureal3dk &taussag) {
+                              real2dk const &asy_table, real3dk &tau, real3dk &taussa, real3dk &taussag) {
     // do ibnd = 1, nbnd
     //   do ilay = 1,nlay
     //     do icol = 1, ncol
@@ -924,7 +924,7 @@ public:
                              int m_ext, int n_ext, real1dk const &re_bounds_ext, real3dk const &coeffs_ext,
                              int m_ssa, int n_ssa, real1dk const &re_bounds_ssa, real3dk const &coeffs_ssa,
                              int m_asy, int n_asy, real1dk const &re_bounds_asy, real3dk const &coeffs_asy,
-                             ureal3dk &tau, ureal3dk &taussa, ureal3dk &taussag) {
+                             real3dk &tau, real3dk &taussa, real3dk &taussag) {
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1, ncol

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp
@@ -597,9 +597,9 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
 
   using pool = conv::MemPoolSingleton;
   const int dsize = ncol *nlay;
-  real* data = pool::alloc<real>(dsize*2);
-  real2dk ftemp (data,ncol,nlay);
-  real2dk fpress(data + dsize,ncol,nlay);
+  real* data = pool::alloc<real>(dsize*2), *dcurr = data;
+  real2dk ftemp (dcurr,ncol,nlay); dcurr += dsize;
+  real2dk fpress(dcurr,ncol,nlay); dcurr += dsize;
 
   real tiny = std::numeric_limits<real>::min();
 
@@ -648,7 +648,7 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
     fmajor(1,1,itemp,iflav,icol,ilay) =       fpress(icol,ilay)  * fminor(1,itemp,iflav,icol,ilay);
   });
 
-  pool::dealloc(data, dsize*2);
+  pool::dealloc(data, dcurr - data);
 }
 
 void combine_and_reorder_2str(int ncol, int nlay, int ngpt, real3dk const &tau_abs, real3dk const &tau_rayleigh,
@@ -692,9 +692,9 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
 
   const int dsize1 = ngpt*nlay*ncol;
   const int dsize2 = ngpt*(nlay+1)*ncol;
-  real* data = pool::alloc<real>(dsize1 + dsize2);
-  real3dk pfrac          (data,ngpt,nlay,ncol);
-  real3dk planck_function(data + dsize1,nbnd,nlay+1,ncol);
+  real* data = pool::alloc<real>(dsize1 + dsize2), *dcurr = data;
+  real3dk pfrac          (dcurr,ngpt,nlay,ncol);   dcurr += dsize1;
+  real3dk planck_function(dcurr,nbnd,nlay+1,ncol); dcurr += dsize2;
 
   // Calculation of fraction of band's Planck irradiance associated with each g-point
   // for (int icol=1; icol<=ncol; icol++) {
@@ -785,7 +785,7 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
     }
   });
 
-  pool::dealloc(data, dsize1 + dsize2);
+  pool::dealloc(data, dcurr - data);
 }
 
 
@@ -930,9 +930,9 @@ void compute_tau_absorption(int max_gpt_diff_lower, int max_gpt_diff_upper, int 
   using pool = conv::MemPoolSingleton;
 
   const int dsize = 2*ncol;
-  int* data = pool::alloc<int>(2 * dsize);
-  int2dk itropo_lower(data,ncol,2);
-  int2dk itropo_upper(data+dsize,ncol,2);
+  int* data = pool::alloc<int>(2 * dsize), *icurr = data;
+  int2dk itropo_lower(icurr,ncol,2); icurr += dsize;
+  int2dk itropo_upper(icurr,ncol,2); icurr += dsize;
 
   int huge  = std::numeric_limits<int>::max();
   int small = std::numeric_limits<int>::min();
@@ -1032,6 +1032,6 @@ void compute_tau_absorption(int max_gpt_diff_lower, int max_gpt_diff_upper, int 
                            idx_minor_scaling_upper, kminor_start_upper, play, tlay, col_gas, fminor,
                            jeta, itropo_upper, jtemp, tau);
 
-  pool::dealloc(data, dsize*2);
+  pool::dealloc(data, icurr - data);
 }
 #endif

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp
@@ -595,8 +595,11 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
                    real4dk const &col_mix, bool2dk const &tropo, int4dk const &jeta, int2dk const &jpress) {
   using conv::merge;
 
-  real2dk ftemp ("ftemp" ,ncol,nlay);
-  real2dk fpress("fpress",ncol,nlay);
+  using pool = conv::MemPoolSingleton;
+  const int dsize = ncol *nlay;
+  real* data = pool::alloc<real>(dsize*2);
+  real2dk ftemp (data,ncol,nlay);
+  real2dk fpress(data + dsize,ncol,nlay);
 
   real tiny = std::numeric_limits<real>::min();
 
@@ -644,6 +647,8 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
     fmajor(0,1,itemp,iflav,icol,ilay) =       fpress(icol,ilay)  * fminor(0,itemp,iflav,icol,ilay);
     fmajor(1,1,itemp,iflav,icol,ilay) =       fpress(icol,ilay)  * fminor(1,itemp,iflav,icol,ilay);
   });
+
+  pool::dealloc(data, dsize*2);
 }
 
 void combine_and_reorder_2str(int ncol, int nlay, int ngpt, real3dk const &tau_abs, real3dk const &tau_rayleigh,
@@ -683,11 +688,13 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
                            real totplnk_delta, real2dk const &totplnk, int2dk const &gpoint_flavor, real2dk const &sfc_src,
                            real3dk const &lay_src, real3dk const &lev_src_inc, real3dk const &lev_src_dec) {
   using conv::merge;
+  using pool = conv::MemPoolSingleton;
 
-  real3dk pfrac          ("pfrac"          ,ngpt,nlay,ncol);
-  real3dk planck_function("planck_function",nbnd,nlay+1,ncol);
-  real1dk one            ("one"            ,2);
-  Kokkos::deep_copy(one, 1);
+  const int dsize1 = ngpt*nlay*ncol;
+  const int dsize2 = ngpt*(nlay+1)*ncol;
+  real* data = pool::alloc<real>(dsize1 + dsize2);
+  real3dk pfrac          (data,ngpt,nlay,ncol);
+  real3dk planck_function(data + dsize1,nbnd,nlay+1,ncol);
 
   // Calculation of fraction of band's Planck irradiance associated with each g-point
   // for (int icol=1; icol<=ncol; icol++) {
@@ -777,6 +784,8 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
       lev_src_inc(igpt,ilay,icol+1) = pfrac(igpt,ilay,icol+1) * planck_function(gpoint_bands(igpt),ilay+1,icol+1);
     }
   });
+
+  pool::dealloc(data, dsize1 + dsize2);
 }
 
 
@@ -918,8 +927,12 @@ void compute_tau_absorption(int max_gpt_diff_lower, int max_gpt_diff_upper, int 
                             int1dk const &kminor_start_upper, bool2dk const &tropo, real4dk const &col_mix, real6dk const &fmajor,
                             real5dk const &fminor, real2dk const &play, real2dk const &tlay, realOff3dk const &col_gas, int4dk const &jeta,
                             int2dk const &jtemp, int2dk const &jpress, real3dk const &tau, bool top_at_1) {
-  int2dk itropo_lower("itropo_lower",ncol,2);
-  int2dk itropo_upper("itropo_upper",ncol,2);
+  using pool = conv::MemPoolSingleton;
+
+  const int dsize = 2*ncol;
+  int* data = pool::alloc<int>(2 * dsize);
+  int2dk itropo_lower(data,ncol,2);
+  int2dk itropo_upper(data+dsize,ncol,2);
 
   int huge  = std::numeric_limits<int>::max();
   int small = std::numeric_limits<int>::min();
@@ -1018,5 +1031,7 @@ void compute_tau_absorption(int max_gpt_diff_lower, int max_gpt_diff_upper, int 
                            minor_scales_with_density_upper, scale_by_complement_upper, idx_minor_upper,
                            idx_minor_scaling_upper, kminor_start_upper, play, tlay, col_gas, fminor,
                            jeta, itropo_upper, jtemp, tau);
+
+  pool::dealloc(data, dsize*2);
 }
 #endif

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -203,9 +203,10 @@ real interpolate2D(real2dk const &fminor, real3dk const &k, int igpt, int1dk con
 //
 // One dimensional interpolation -- return all values along second table dimension
 //
+template <typename View>
 KOKKOS_INLINE_FUNCTION
 void interpolate1D(real val, real offset, real delta, real2dk const &table,
-                   real1dk const &res, int tab_d1, int tab_d2) {
+                   View const &res, int tab_d1, int tab_d2) {
   real val0 = (val - offset) / delta;
   real frac = val0 - int(val0); // get fractional part
   int index = Kokkos::fmin(tab_d1-1, Kokkos::fmax(1, (int)(val0)+1)) - 1; // limit the index range

--- a/cpp/rrtmgp/mo_gas_concentrations.h
+++ b/cpp/rrtmgp/mo_gas_concentrations.h
@@ -350,7 +350,8 @@ public:
 
   // Get concentration as a 2-D field of columns and levels
   // array is expected to be in device memory
-  void get_vmr(std::string gas, real2dk const &array) const {
+  template <typename View>
+  void get_vmr(std::string gas, View const &array) const {
     if (this->ncol != array.extent(0)) { stoprun("ty_gas_concs->get_vmr; gas array is wrong size (ncol)" ); }
     if (this->nlay != array.extent(1)) { stoprun("ty_gas_concs->get_vmr; gas array is wrong size (nlay)" ); }
     int igas = this->find_gas(gas);

--- a/cpp/rrtmgp/mo_gas_concentrations.h
+++ b/cpp/rrtmgp/mo_gas_concentrations.h
@@ -170,7 +170,7 @@ public:
 
 
   // Get concentration as a 2-D field of columns and levels
-  // array is expected to be in devide memory
+  // array is expected to be in device memory
   void get_vmr(std::string gas, real2d const &array) const {
     using yakl::intrinsics::size;
     using yakl::fortran::parallel_for;
@@ -349,7 +349,7 @@ public:
   }
 
   // Get concentration as a 2-D field of columns and levels
-  // array is expected to be in devide memory
+  // array is expected to be in device memory
   void get_vmr(std::string gas, real2dk const &array) const {
     if (this->ncol != array.extent(0)) { stoprun("ty_gas_concs->get_vmr; gas array is wrong size (ncol)" ); }
     if (this->nlay != array.extent(1)) { stoprun("ty_gas_concs->get_vmr; gas array is wrong size (nlay)" ); }
@@ -358,6 +358,7 @@ public:
     // for (int ilay=1; ilay<=size(array,2); ilay++) {
     //   for (int icol=1; icol<=size(array,1); icol++) {
     auto this_concs = this->concs;
+    std::cout << "JGF: " << array.extent(1) << ", " << array.extent(0) << std::endl;
     Kokkos::parallel_for( MDRangeP<2>({0,0}, {array.extent(1),array.extent(0)}) , KOKKOS_LAMBDA (int ilay, int icol) {
       array(icol,ilay) = this_concs(icol,ilay,igas);
     });

--- a/cpp/rrtmgp/mo_gas_concentrations.h
+++ b/cpp/rrtmgp/mo_gas_concentrations.h
@@ -358,7 +358,6 @@ public:
     // for (int ilay=1; ilay<=size(array,2); ilay++) {
     //   for (int icol=1; icol<=size(array,1); icol++) {
     auto this_concs = this->concs;
-    std::cout << "JGF: " << array.extent(1) << ", " << array.extent(0) << std::endl;
     Kokkos::parallel_for( MDRangeP<2>({0,0}, {array.extent(1),array.extent(0)}) , KOKKOS_LAMBDA (int ilay, int icol) {
       array(icol,ilay) = this_concs(icol,ilay,igas);
     });

--- a/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
+++ b/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
@@ -1990,11 +1990,11 @@ public:
     int ngpt  = this->get_ngpt();
     int nband = this->get_nband();
     // Interpolation coefficients for use in source function
-    int2dk  jtemp (pool::alloc<int>(ncol*nlay),  ncol,nlay);
-    int2dk  jpress(pool::alloc<int>(ncol*nlay),  ncol,nlay);
-    int4dk  jeta  (pool::alloc<int>(2*this->get_nflav()*ncol*nlay), 2, this->get_nflav(), ncol, nlay);
-    bool2dk tropo (pool::alloc<bool>(ncol*nlay), ncol,nlay);
-    real6dk fmajor(pool::alloc<real>(2*2*2*this->get_nflav()*ncol*nlay), 2,2,2,this->get_nflav(),ncol,nlay);
+    int2dk  jtemp  = pool::alloc<int2dk> (ncol, nlay);
+    int2dk  jpress = pool::alloc<int2dk> (ncol, nlay);
+    int4dk  jeta   = pool::alloc<int4dk> (2, this->get_nflav(), ncol, nlay);
+    bool2dk tropo  = pool::alloc<bool2dk>(ncol, nlay);
+    real6dk fmajor = pool::alloc<real6dk>(2,2,2,this->get_nflav(),ncol,nlay);
     // Gas optics
     compute_gas_taus(top_at_1, ncol, nlay, ngpt, nband, play, plev, tlay, gas_desc, col_gas, optical_props, jtemp, jpress,
                      jeta, tropo, fmajor, col_dry);
@@ -2024,11 +2024,11 @@ public:
     // Interpolate source function
     this->source(top_at_1, ncol, nlay, nband, ngpt, play, plev, tlay, tsfc, jtemp, jpress, jeta, tropo, fmajor, sources, tlev);
 
-    pool::dealloc(jtemp.data(), jtemp.size());
-    pool::dealloc(jpress.data(), jpress.size());
-    pool::dealloc(tropo.data(), tropo.size());
-    pool::dealloc(fmajor.data(), fmajor.size());
-    pool::dealloc(jeta.data(), jeta.size());
+    pool::dealloc(jtemp);
+    pool::dealloc(jpress);
+    pool::dealloc(tropo);
+    pool::dealloc(fmajor);
+    pool::dealloc(jeta);
   }
 
   // Compute gas optical depth given temperature, pressure, and composition
@@ -2044,11 +2044,11 @@ public:
     int nflav = get_nflav();
 
     // Interpolation coefficients for use in source function
-    int2dk  jtemp (pool::alloc<int>(ncol*nlay),  ncol,nlay);
-    int2dk  jpress(pool::alloc<int>(ncol*nlay),  ncol,nlay);
-    bool2dk tropo (pool::alloc<bool>(ncol*nlay), ncol,nlay);
-    real6dk fmajor(pool::alloc<real>(2*2*2*this->get_nflav()*ncol*nlay), 2,2,2,this->get_nflav(),ncol,nlay);
-    int4dk  jeta  (pool::alloc<int>(2*this->get_nflav()*ncol*nlay), 2, this->get_nflav(), ncol, nlay);
+    int2dk  jtemp  = pool::alloc<int2dk> (ncol,nlay);
+    int2dk  jpress = pool::alloc<int2dk> (ncol,nlay);
+    bool2dk tropo  = pool::alloc<bool2dk>(ncol,nlay);
+    real6dk fmajor = pool::alloc<real6dk>(2,2,2,this->get_nflav(),ncol,nlay);
+    int4dk  jeta   = pool::alloc<int4dk> (2,this->get_nflav(),ncol,nlay);
     // Gas optics
     compute_gas_taus(top_at_1, ncol, nlay, ngpt, nband, play, plev, tlay, gas_desc, col_gas, optical_props, jtemp, jpress, jeta,
                      tropo, fmajor, col_dry);
@@ -2061,11 +2061,11 @@ public:
       toa_src(icol,igpt) = this_solar_src(igpt);
     });
 
-    pool::dealloc(jtemp.data(), jtemp.size());
-    pool::dealloc(jpress.data(), jpress.size());
-    pool::dealloc(tropo.data(), tropo.size());
-    pool::dealloc(fmajor.data(), fmajor.size());
-    pool::dealloc(jeta.data(), jeta.size());
+    pool::dealloc(jtemp);
+    pool::dealloc(jpress);
+    pool::dealloc(tropo);
+    pool::dealloc(fmajor);
+    pool::dealloc(jeta);
   }
 
   // Returns optical properties and interpolation coefficients
@@ -2188,7 +2188,7 @@ public:
 
     pool::dealloc(data, dcurr - data);
     if (dealloc_col_dry) {
-      pool::dealloc(col_dry_wk.data(), col_dry_wk.size());
+      pool::dealloc(col_dry_wk);
     }
   }
 

--- a/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
+++ b/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
@@ -2134,7 +2134,7 @@ public:
       // Get vmr if  gas is provided in ty_gas_concs
       for (size_t igas2 = 0 ; igas2 < gas_desc.gas_name.size() ; igas2++) {
         if ( lower_case(this->gas_names[igas]) == lower_case(gas_desc.gas_name[igas2]) ) {
-          real2dk vmr_slice = Kokkos::subview(vmr, Kokkos::ALL, Kokkos::ALL, igas);
+          auto vmr_slice = Kokkos::subview(vmr, Kokkos::ALL, Kokkos::ALL, igas);
           gas_desc.get_vmr(this->gas_names[igas], vmr_slice);
         }
       }
@@ -2259,7 +2259,8 @@ public:
 
   // Utility function, provided for user convenience
   // computes column amounts of dry air using hydrostatic equation
-  real2dk get_col_dry(real2dk const &vmr_h2o, real2dk const &plev, real1dk const &latitude=real1dk()) {
+  template <typename View>
+  real2dk get_col_dry(View const &vmr_h2o, real2dk const &plev, real1dk const &latitude=real1dk()) {
     using pool = conv::MemPoolSingleton;
 
     // first and second term of Helmert formula

--- a/cpp/rrtmgp_const.h
+++ b/cpp/rrtmgp_const.h
@@ -27,32 +27,6 @@ using FOView = Kokkos::Experimental::OffsetView<T, Kokkos::LayoutLeft, Device>;
 
 template <int Rank, typename ExecutionSpace=Kokkos::DefaultExecutionSpace>
 using MDRangeP = Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<Rank> >;//, Kokkos::Iterate::Right, Kokkos::Iterate::Left> >;
-
-// Copied from EKAT
-template <typename View>
-struct MemoryTraitsMask {
-  enum : unsigned int {
-    value = ((View::traits::memory_traits::is_random_access ? Kokkos::RandomAccess : 0) |
-             (View::traits::memory_traits::is_atomic ? Kokkos::Atomic : 0) |
-             (View::traits::memory_traits::is_restrict ? Kokkos::Restrict : 0) |
-             (View::traits::memory_traits::is_aligned ? Kokkos::Aligned : 0) |
-             (View::traits::memory_traits::is_unmanaged ? Kokkos::Unmanaged : 0))
-      };
-};
-
-// Copied from EKAT
-template <typename View>
-using Unmanaged =
-  // Provide a full View type specification, augmented with Unmanaged.
-  Kokkos::View<typename View::traits::scalar_array_type,
-               typename View::traits::array_layout,
-               typename View::traits::device_type,
-               Kokkos::MemoryTraits<
-                 // All the current values...
-                 MemoryTraitsMask<View>::value |
-                 // ... |ed with the one we want, whether or not it's
-                 // already there.
-                 Kokkos::Unmanaged> >;
 #endif
 
 typedef double real;

--- a/cpp/rrtmgp_const.h
+++ b/cpp/rrtmgp_const.h
@@ -213,6 +213,22 @@ typedef Unmanaged<FView<real*****>>   ureal5dk;
 typedef Unmanaged<FView<real******>>  ureal6dk;
 typedef Unmanaged<FView<real*******>> ureal7dk;
 
+typedef Unmanaged<FView<bool*>>       ubool1dk;
+typedef Unmanaged<FView<bool**>>      ubool2dk;
+typedef Unmanaged<FView<bool***>>     ubool3dk;
+typedef Unmanaged<FView<bool****>>    ubool4dk;
+typedef Unmanaged<FView<bool*****>>   ubool5dk;
+typedef Unmanaged<FView<bool******>>  ubool6dk;
+typedef Unmanaged<FView<bool*******>> ubool7dk;
+
+typedef Unmanaged<FView<int*>>       uint1dk;
+typedef Unmanaged<FView<int**>>      uint2dk;
+typedef Unmanaged<FView<int***>>     uint3dk;
+typedef Unmanaged<FView<int****>>    uint4dk;
+typedef Unmanaged<FView<int*****>>   uint5dk;
+typedef Unmanaged<FView<int******>>  uint6dk;
+typedef Unmanaged<FView<int*******>> uint7dk;
+
 #endif
 
 typedef std::vector<std::string> string1dv;

--- a/cpp/rrtmgp_const.h
+++ b/cpp/rrtmgp_const.h
@@ -27,6 +27,32 @@ using FOView = Kokkos::Experimental::OffsetView<T, Kokkos::LayoutLeft, Device>;
 
 template <int Rank, typename ExecutionSpace=Kokkos::DefaultExecutionSpace>
 using MDRangeP = Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<Rank> >;//, Kokkos::Iterate::Right, Kokkos::Iterate::Left> >;
+
+// Copied from EKAT
+template <typename View>
+struct MemoryTraitsMask {
+  enum : unsigned int {
+    value = ((View::traits::memory_traits::is_random_access ? Kokkos::RandomAccess : 0) |
+             (View::traits::memory_traits::is_atomic ? Kokkos::Atomic : 0) |
+             (View::traits::memory_traits::is_restrict ? Kokkos::Restrict : 0) |
+             (View::traits::memory_traits::is_aligned ? Kokkos::Aligned : 0) |
+             (View::traits::memory_traits::is_unmanaged ? Kokkos::Unmanaged : 0))
+      };
+};
+
+// Copied from EKAT
+template <typename View>
+using Unmanaged =
+  // Provide a full View type specification, augmented with Unmanaged.
+  Kokkos::View<typename View::traits::scalar_array_type,
+               typename View::traits::array_layout,
+               typename View::traits::device_type,
+               Kokkos::MemoryTraits<
+                 // All the current values...
+                 MemoryTraitsMask<View>::value |
+                 // ... |ed with the one we want, whether or not it's
+                 // already there.
+                 Kokkos::Unmanaged> >;
 #endif
 
 typedef double real;
@@ -177,6 +203,16 @@ typedef FView<char**, HostDevice> charHost2dk;
 // this is useful in a couple situations
 typedef FOView<real***>             realOff3dk;
 typedef FOView<real***, HostDevice> realOffHost3dk;
+
+// Unmanaged views
+typedef Unmanaged<FView<real*>>       ureal1dk;
+typedef Unmanaged<FView<real**>>      ureal2dk;
+typedef Unmanaged<FView<real***>>     ureal3dk;
+typedef Unmanaged<FView<real****>>    ureal4dk;
+typedef Unmanaged<FView<real*****>>   ureal5dk;
+typedef Unmanaged<FView<real******>>  ureal6dk;
+typedef Unmanaged<FView<real*******>> ureal7dk;
+
 #endif
 
 typedef std::vector<std::string> string1dv;

--- a/cpp/rrtmgp_const.h
+++ b/cpp/rrtmgp_const.h
@@ -203,32 +203,6 @@ typedef FView<char**, HostDevice> charHost2dk;
 // this is useful in a couple situations
 typedef FOView<real***>             realOff3dk;
 typedef FOView<real***, HostDevice> realOffHost3dk;
-
-// Unmanaged views
-typedef Unmanaged<FView<real*>>       ureal1dk;
-typedef Unmanaged<FView<real**>>      ureal2dk;
-typedef Unmanaged<FView<real***>>     ureal3dk;
-typedef Unmanaged<FView<real****>>    ureal4dk;
-typedef Unmanaged<FView<real*****>>   ureal5dk;
-typedef Unmanaged<FView<real******>>  ureal6dk;
-typedef Unmanaged<FView<real*******>> ureal7dk;
-
-typedef Unmanaged<FView<bool*>>       ubool1dk;
-typedef Unmanaged<FView<bool**>>      ubool2dk;
-typedef Unmanaged<FView<bool***>>     ubool3dk;
-typedef Unmanaged<FView<bool****>>    ubool4dk;
-typedef Unmanaged<FView<bool*****>>   ubool5dk;
-typedef Unmanaged<FView<bool******>>  ubool6dk;
-typedef Unmanaged<FView<bool*******>> ubool7dk;
-
-typedef Unmanaged<FView<int*>>       uint1dk;
-typedef Unmanaged<FView<int**>>      uint2dk;
-typedef Unmanaged<FView<int***>>     uint3dk;
-typedef Unmanaged<FView<int****>>    uint4dk;
-typedef Unmanaged<FView<int*****>>   uint5dk;
-typedef Unmanaged<FView<int******>>  uint6dk;
-typedef Unmanaged<FView<int*******>> uint7dk;
-
 #endif
 
 typedef std::vector<std::string> string1dv;

--- a/cpp/rrtmgp_const.h
+++ b/cpp/rrtmgp_const.h
@@ -26,7 +26,11 @@ template <typename T, typename Device=DefaultDevice>
 using FOView = Kokkos::Experimental::OffsetView<T, Kokkos::LayoutLeft, Device>;
 
 template <int Rank, typename ExecutionSpace=Kokkos::DefaultExecutionSpace>
-using MDRangeP = Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<Rank> >;//, Kokkos::Iterate::Right, Kokkos::Iterate::Left> >;
+#ifdef KOKKOS_ENABLE_CUDA
+using MDRangeP = Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<Rank, Kokkos::Iterate::Left, Kokkos::Iterate::Right> >;
+#else
+using MDRangeP = Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<Rank> >;
+#endif
 #endif
 
 typedef double real;

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -424,7 +424,9 @@ struct MemPoolSingleton
   T* alloc(const int num) noexcept
   {
     std::cout << "JGF Trying to allocate: " << num * sizeof(T) << " bytes" << std::endl;
-    return reinterpret_cast<T*>(s_device_mem_pool.allocate(num * sizeof(T)));
+    T* rv = reinterpret_cast<T*>(s_device_mem_pool.allocate(num * sizeof(T)));
+    assert(rv != nullptr);
+    return rv;
   }
 
   template <typename T>

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -989,8 +989,6 @@ public:
     using T       = typename View::non_const_value_type;
 
     using LeftHostView = Kokkos::View<typename View::non_const_data_type, Kokkos::LayoutLeft, HostDevice>;
-    constexpr bool is_c_layout   = std::is_same<myStyle, Kokkos::LayoutRight>::value;
-    constexpr bool is_device_mem = !std::is_same<myMem, Kokkos::DefaultHostExecutionSpace::memory_space>::value;
     constexpr auto rank = View::rank;
 
     // Make sure the variable is there and is the right dimension

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -409,10 +409,10 @@ struct MemPoolSingleton
 {
  public:
   static inline Kokkos::View<real*> s_mem;
-  static inline size_t s_curr_used;
-  static inline size_t s_high_water;
+  static inline int64_t s_curr_used;
+  static inline int64_t s_high_water;
 
-  static void init(const size_t capacity)
+  static void init(const int64_t capacity)
   {
     static bool is_init = false;
     RRT_REQUIRE(!is_init, "Multiple MemPoolSingleton inits");
@@ -423,10 +423,10 @@ struct MemPoolSingleton
 
   template <typename T>
   static inline
-  T* alloc(const int num) noexcept
+  T* alloc(const int64_t num) noexcept
   {
     assert(sizeof(T) <= sizeof(real));
-    const size_t num_reals = (num * sizeof(T) + (sizeof(real) - 1)) / sizeof(real);
+    const int64_t num_reals = (num * sizeof(T) + (sizeof(real) - 1)) / sizeof(real);
     T* rv = reinterpret_cast<T*>(s_mem.data() + s_curr_used);
     s_curr_used += num_reals;
     assert(s_curr_used <= s_mem.size());
@@ -438,9 +438,9 @@ struct MemPoolSingleton
 
   template <typename T>
   static inline
-  void dealloc(const T*, const int num) noexcept
+  void dealloc(const T*, const int64_t num) noexcept
   {
-    const size_t num_reals = (num * sizeof(T) + (sizeof(real) - 1)) / sizeof(real);
+    const int64_t num_reals = (num * sizeof(T) + (sizeof(real) - 1)) / sizeof(real);
     s_curr_used -= num_reals;
     assert(s_curr_used >= 0);
   }
@@ -448,6 +448,7 @@ struct MemPoolSingleton
   static inline
   void finalize()
   {
+    print_state();
     s_mem = Kokkos::View<real*>();
   }
 

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -436,6 +436,42 @@ struct MemPoolSingleton
     return rv;
   }
 
+  template <typename View,
+            typename std::enable_if<is_view_v<View>>::type* = nullptr>
+  static inline
+  View alloc(const int64_t dim1) noexcept
+  { return View(alloc<typename View::non_const_value_type>(dim1), dim1); }
+
+  template <typename View,
+            typename std::enable_if<is_view_v<View>>::type* = nullptr>
+  static inline
+  View alloc(const int64_t dim1, const int64_t dim2) noexcept
+  { return View(alloc<typename View::non_const_value_type>(dim1*dim2), dim1, dim2); }
+
+  template <typename View,
+            typename std::enable_if<is_view_v<View>>::type* = nullptr>
+  static inline
+  View alloc(const int64_t dim1, const int64_t dim2, const int64_t dim3) noexcept
+  { return View(alloc<typename View::non_const_value_type>(dim1*dim2*dim3), dim1, dim2, dim3); }
+
+  template <typename View,
+            typename std::enable_if<is_view_v<View>>::type* = nullptr>
+  static inline
+  View alloc(const int64_t dim1, const int64_t dim2, const int64_t dim3, const int64_t dim4) noexcept
+  { return View(alloc<typename View::non_const_value_type>(dim1*dim2*dim3*dim4), dim1, dim2, dim3, dim4); }
+
+  template <typename View,
+            typename std::enable_if<is_view_v<View>>::type* = nullptr>
+  static inline
+  View alloc(const int64_t dim1, const int64_t dim2, const int64_t dim3, const int64_t dim4, const int dim5) noexcept
+  { return View(alloc<typename View::non_const_value_type>(dim1*dim2*dim3*dim4*dim5), dim1, dim2, dim3, dim4, dim5); }
+
+  template <typename View,
+            typename std::enable_if<is_view_v<View>>::type* = nullptr>
+  static inline
+  View alloc(const int64_t dim1, const int64_t dim2, const int64_t dim3, const int64_t dim4, const int dim5, const int dim6) noexcept
+  { return View(alloc<typename View::non_const_value_type>(dim1*dim2*dim3*dim4*dim5*dim6), dim1, dim2, dim3, dim4, dim5, dim6); }
+
   template <typename T>
   static inline
   void dealloc(const T*, const int64_t num) noexcept
@@ -443,6 +479,13 @@ struct MemPoolSingleton
     const int64_t num_reals = (num * sizeof(T) + (sizeof(real) - 1)) / sizeof(real);
     s_curr_used -= num_reals;
     assert(s_curr_used >= 0);
+  }
+
+  template <typename View>
+  static inline
+  void dealloc(const View& view) noexcept
+  {
+    dealloc(view.data(), view.size());
   }
 
   static inline

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -449,6 +449,7 @@ struct MemPoolSingleton
   void finalize()
   {
     print_state();
+    assert(s_curr_used == 0); // !=0 indicates we may have forgetten a dealloc
     s_mem = Kokkos::View<real*>();
   }
 

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -409,21 +409,19 @@ struct MemPoolSingleton
   inline static HostMemPool   s_host_mem_pool;
 
   static void init(
-    const int dev_capacity, const int dev_min_block_size, const int dev_max_block_size, const int dev_super_block_size,
-    const int hst_capacity, const int hst_min_block_size, const int hst_max_block_size, const int hst_super_block_size)
+    const size_t dev_capacity, const size_t dev_min_block_size, const size_t dev_max_block_size, const size_t dev_super_block_size,
+    const size_t hst_capacity, const size_t hst_min_block_size, const size_t hst_max_block_size, const size_t hst_super_block_size)
   {
     static bool is_init = false;
     RRT_REQUIRE(!is_init, "Multiple MemPoolSingleton inits");
     s_device_mem_pool = DeviceMemPool(typename DefaultDevice::memory_space(), dev_capacity, dev_min_block_size, dev_max_block_size, dev_super_block_size);
-    s_host_mem_pool = HostMemPool(typename HostDevice::memory_space(), hst_capacity, hst_min_block_size, hst_max_block_size, hst_super_block_size);
-    s_device_mem_pool.print_state(std::cout);
+    //s_host_mem_pool = HostMemPool(typename HostDevice::memory_space(), hst_capacity, hst_min_block_size, hst_max_block_size, hst_super_block_size);
   }
 
   template <typename T>
   static inline
   T* alloc(const int num) noexcept
   {
-    std::cout << "JGF Trying to allocate: " << num * sizeof(T) << " bytes" << std::endl;
     T* rv = reinterpret_cast<T*>(s_device_mem_pool.allocate(num * sizeof(T)));
     assert(rv != nullptr);
     return rv;
@@ -433,7 +431,9 @@ struct MemPoolSingleton
   static inline
   T* alloc_host(const int num) noexcept
   {
-    return reinterpret_cast<T*>(s_host_mem_pool.allocate(num * sizeof(T)));
+    T* rv = reinterpret_cast<T*>(s_host_mem_pool.allocate(num * sizeof(T)));
+    assert(rv != nullptr);
+    return rv;
   }
 
   template <typename T>
@@ -455,6 +455,12 @@ struct MemPoolSingleton
   {
     s_device_mem_pool = DeviceMemPool();
     s_host_mem_pool = HostMemPool();
+  }
+
+  static inline
+  void print_state()
+  {
+    s_device_mem_pool.print_state(std::cout);
   }
 };
 

--- a/cpp/rte/kernels/mo_rte_solver_kernels.h
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.h
@@ -488,8 +488,9 @@ inline void sw_two_stream(int ncol, int nlay, int ngpt, real1dk const &mu0, real
                           real3dk const &w0, real3dk const &g, real3dk &Rdif, real3dk const &Tdif,
                           real3dk const &Rdir, real3dk const &Tdir, real3dk const &Tnoscat) {
   using conv::merge;
+  using pool = conv::MemPoolSingleton;
 
-  real1dk mu0_inv("mu0_inv",ncol);
+  real1dk mu0_inv(pool::alloc<real>(ncol), ncol);
 
   real eps = std::numeric_limits<real>::epsilon();
 
@@ -562,6 +563,8 @@ inline void sw_two_stream(int ncol, int nlay, int ngpt, real1dk const &mu0, real
                           2.0 * (k_gamma4 + alpha1 * k_mu)  * exp_minusktau );
 
   });
+
+  pool::dealloc(mu0_inv.data(), mu0_inv.size());
 }
 
 

--- a/cpp/rte/mo_rte_lw.h
+++ b/cpp/rte/mo_rte_lw.h
@@ -175,7 +175,7 @@ void rte_lw(int max_gauss_pts, real2dk const &gauss_Ds, real2dk const &gauss_wts
 
   const int dsize1 = ncol * (nlay+1) * ngpt;
   const int dsize2 = ncol * ngpt;
-  real* data = pool::alloc<real>(dsize1*2 + dsize2), *dcurr = data;
+  real* data = pool::alloc<real>(dsize1*2 + dsize2 + 2*n_quad_angs), *dcurr = data;
   real3dk gpt_flux_up (dcurr,ncol,nlay+1,ngpt); dcurr += dsize1;
   real3dk gpt_flux_dn (dcurr,ncol,nlay+1,ngpt); dcurr += dsize1;
   real2dk sfc_emis_gpt(dcurr,ncol       ,ngpt); dcurr += dsize2;

--- a/cpp/rte/mo_rte_sw.h
+++ b/cpp/rte/mo_rte_sw.h
@@ -140,11 +140,11 @@ void rte_sw(OpticalProps2strK const &atmos, bool top_at_1, real1dk const &mu0, r
   const int dsize1 = ncol * (nlay+1) * ngpt;
   const int dsize2 = ncol * ngpt;
   real* data = pool::alloc<real>(dsize1*3 + dsize2*2), *dcurr = data;
-  real3dk gpt_flux_up(dcurr,ncol, nlay+1, ngpt); dcurr += dsize1;
-  real3dk gpt_flux_dn(dcurr,ncol, nlay+1, ngpt); dcurr += dsize1;
-  real3dk gpt_flux_dir(dcurr,ncol, nlay+1, ngpt);  dcurr += dsize1;
-  real2dk sfc_alb_dir_gpt(dcurr,ncol, ngpt);  dcurr += dsize2;
-  real2dk sfc_alb_dif_gpt(dcurr,ncol, ngpt);  dcurr += dsize2;
+  real3dk gpt_flux_up    (dcurr,ncol, nlay+1, ngpt); dcurr += dsize1;
+  real3dk gpt_flux_dn    (dcurr,ncol, nlay+1, ngpt); dcurr += dsize1;
+  real3dk gpt_flux_dir   (dcurr,ncol, nlay+1, ngpt); dcurr += dsize1;
+  real2dk sfc_alb_dir_gpt(dcurr,ncol, ngpt);         dcurr += dsize2;
+  real2dk sfc_alb_dif_gpt(dcurr,ncol, ngpt);         dcurr += dsize2;
 
   // Error checking -- consistency of sizes and validity of values
   if (! fluxes.are_desired()) { stoprun("rte_sw: no space allocated for fluxes"); }

--- a/cpp/test/build/test_sw_perf.sh
+++ b/cpp/test/build/test_sw_perf.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+
+loops=${1-10}
+
+$RUNCMD ./allsky/allsky input_files/rrtmgp-allsky.nc                  \
+                        input_files/rrtmgp-data-sw-g224-2018-12-04.nc \
+                        input_files/rrtmgp-cloud-optics-coeffs-sw.nc  \
+                        1000                                          \
+                        $loops


### PR DESCRIPTION
Use Kokkos' MemoryPool for temp views. The current approach was a little tedious, but I can't think of a better way to do it. EKAT workspace manager is not really an option due to the heterogeneity of the types and sizes of temporary views.

This closes a significant performance gap between the YAKL and Kokkos impls of RRTMGP.

Mappy 1 thread:
```
YAKL:           Longwave did 10 loops of 1000 cols and 42 layers in 17.041446 s
Kokkos no pool: Longwave did 10 loops of 1000 cols and 42 layers in 19.643913 s
Kokkos pool:    Longwave did 10 loops of 1000 cols and 42 layers in 14.302554 s
```

Mappy 64 threads:
```
YAKL:           Longwave did 10 loops of 1000 cols and 42 layers in 0.880673 s
Kokkos no pool: Longwave did 10 loops of 1000 cols and 42 layers in 7.94706 s
Kokkos pool:    Longwave did 10 loops of 1000 cols and 42 layers in 1.182028 s
```

Weaver (CUDA):
```
YAKL:                             Longwave did 10 loops of 1000 cols and 42 layers in 0.100984 s
Kokkos no pool:                   Longwave did 10 loops of 1000 cols and 42 layers in 1.11428 s
Kokkos pool:                      Longwave did 10 loops of 1000 cols and 42 layers in 0.741237 s
Kokkos pool + MDRange left-right: Longwave did 10 loops of 1000 cols and 42 layers in 0.212644 s
```
