### PR TITLE
Update to work with latest eamxx

### DIFF
--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -140,8 +140,7 @@ int main(int argc , char **argv) {
     auto p_lay_host = p_lay.createHostCopy();
 #endif
 #ifdef RRTMGP_ENABLE_KOKKOS
-    auto p_lay_host_k = Kokkos::create_mirror_view(p_lay_k);
-    Kokkos::deep_copy(p_lay_host_k, p_lay_k);
+    auto p_lay_host_k = Kokkos::create_mirror_view_and_copy(HostDevice(), p_lay_k);
 #endif
     bool top_at_1 = COMPUTE_SWITCH(p_lay_host(1, 1) < p_lay_host(1, nlay), p_lay_host_k(0, 0) < p_lay_host_k(0, nlay-1));
 
@@ -494,8 +493,7 @@ int main(int argc , char **argv) {
       real1dk t_sfc_k   ("t_sfc"        ,ncol);
       real2dk emis_sfc_k("emis_sfc",nbnd,ncol);
       // Surface temperature
-      auto t_lev_host_k = Kokkos::create_mirror_view(t_lev_k);
-      Kokkos::deep_copy(t_lev_host_k, t_lev_k);
+      auto t_lev_host_k = Kokkos::create_mirror_view_and_copy(HostDevice(), t_lev_k);
       Kokkos::deep_copy(t_sfc_k, t_lev_host_k(0, merge(nlay, 0, top_at_1)));
       Kokkos::deep_copy(emis_sfc_k, 0.98);
       COMPARE_WRAP(t_sfc, t_sfc_k);

--- a/cpp/examples/mo_load_coefficients.cpp
+++ b/cpp/examples/mo_load_coefficients.cpp
@@ -105,7 +105,41 @@ void load_and_init(GasOpticsRRTMGP &kdist, std::string filename, GasConcs const 
   } else {
     // Otherwise, it's a shortwave type
     realHost1d solar_src;
-    io.read( solar_src , "solar_source" );
+    if (io.varExists("solar_source")) {
+      io.read( solar_src , "solar_source" );
+    } else if (io.varExists("solar_source_quiet")) {
+      // Newer RRTMGP input data files include components of solar source function sufficient to
+      // compute solar variability; ignore this for now, and simply read in the baseline solar source.
+      // This seems to get us closer to the original average insolation from
+      // the full spectral resolution data, but there is disagreement between
+      // this and EAM RRTMG for some reason.
+      // TODO: Ultimately, we need to be able to use solar source data consistent with EAM (i.e., the
+      // input4MIPS data); this will require implementing a separate function
+      // here to read that data in and integrate the solar source over each
+      // wavelength/gpoint band
+      io.read( solar_src            , "solar_source_quiet" );
+      if (false) {
+        realHost1d solar_source_facular;
+        realHost1d solar_source_sunspot;
+        real mg_index;
+        real sb_index;
+        io.read( solar_source_facular , "solar_source_facular" );
+        io.read( solar_source_sunspot , "solar_source_sunspot" );
+        io.read( mg_index, "mg_default");
+        io.read( sb_index, "sb_default");
+        const real a_offset = 0.1495954;
+        const real b_offset = 0.00066696;
+        auto ngpt = solar_src.totElems();
+        yakl::fortran::parallel_for(yakl::fortran::SimpleBounds<1>(ngpt), YAKL_LAMBDA(int igpt) {
+          solar_src(igpt) = solar_src(igpt)
+            + (mg_index - a_offset) * solar_source_facular(igpt)
+            + (sb_index - b_offset) * solar_source_sunspot(igpt);
+        });
+      }
+    } else {
+      std::cout << "ERROR: no solar_source variable found in input data.\n";
+    }
+
     kdist.load(available_gases, gas_names, key_species, band2gpt, band_lims, press_ref, press_ref_trop,
                temp_ref, temp_ref_p, temp_ref_t, vmr_ref, kmajor, kminor_lower, kminor_upper,
                gas_minor, identifier_minor, minor_gases_lower, minor_gases_upper,
@@ -209,7 +243,40 @@ void load_and_init(GasOpticsRRTMGPK &kdist, std::string filename, GasConcsK cons
   } else {
     // Otherwise, it's a shortwave type
     realHost1dk solar_src;
-    io.read( solar_src , "solar_source" );
+    if (io.varExists("solar_source")) {
+      io.read( solar_src , "solar_source" );
+    } else if (io.varExists("solar_source_quiet")) {
+      // Newer RRTMGP input data files include components of solar source function sufficient to
+      // compute solar variability; ignore this for now, and simply read in the baseline solar source.
+      // This seems to get us closer to the original average insolation from
+      // the full spectral resolution data, but there is disagreement between
+      // this and EAM RRTMG for some reason.
+      // TODO: Ultimately, we need to be able to use solar source data consistent with EAM (i.e., the
+      // input4MIPS data); this will require implementing a separate function
+      // here to read that data in and integrate the solar source over each
+      // wavelength/gpoint band
+      io.read( solar_src            , "solar_source_quiet" );
+      if (false) {
+        // realHost1d solar_source_facular;
+        // realHost1d solar_source_sunspot;
+        // real mg_index;
+        // real sb_index;
+        // io.read( solar_source_facular , "solar_source_facular" );
+        // io.read( solar_source_sunspot , "solar_source_sunspot" );
+        // io.read( mg_index, "mg_default");
+        // io.read( sb_index, "sb_default");
+        // const real a_offset = 0.1495954;
+        // const real b_offset = 0.00066696;
+        // auto ngpt = solar_src.totElems();
+        // yakl::fortran::parallel_for(yakl::fortran::SimpleBounds<1>(ngpt), YAKL_LAMBDA(int igpt) {
+        //   solar_src(igpt) = solar_src(igpt)
+        //     + (mg_index - a_offset) * solar_source_facular(igpt)
+        //     + (sb_index - b_offset) * solar_source_sunspot(igpt);
+        // });
+      }
+    } else {
+      std::cout << "ERROR: no solar_source variable found in input data.\n";
+    }
     kdist.load(available_gases, gas_names, key_species, band2gpt, band_lims, press_ref, press_ref_trop,
                temp_ref, temp_ref_p, temp_ref_t, vmr_ref, kmajor, kminor_lower, kminor_upper,
                gas_minor, identifier_minor, minor_gases_lower, minor_gases_upper,

--- a/cpp/rrtmgp/mo_gas_concentrations.h
+++ b/cpp/rrtmgp/mo_gas_concentrations.h
@@ -314,7 +314,7 @@ public:
     bool badVal = false;
     Kokkos::parallel_reduce(w.extent(0), KOKKOS_LAMBDA(int i, bool& is_bad) {
       if (w(i) < 0. || w(i) > 1.) { is_bad = true; }
-      }, Kokkos::BOr<bool>(badVal));
+      }, Kokkos::LOr<bool>(badVal));
       if (badVal) { stoprun("GasConcs::set_vmr(): concentrations should be >= 0, <= 1"); }
     #endif
     auto this_concs = this->concs;

--- a/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
+++ b/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
@@ -1598,10 +1598,8 @@ public:
                        intHost1dk  const &kminor_start_upper,
                        realHost3dk const &rayl_lower,
                        realHost3dk const &rayl_upper) {
-    auto band_lims_wavenum_h = Kokkos::create_mirror_view(DefaultDevice(), band_lims_wavenum);
-    auto band2gpt_h = Kokkos::create_mirror_view(DefaultDevice(), band2gpt);
-    Kokkos::deep_copy(band_lims_wavenum_h, band_lims_wavenum);
-    Kokkos::deep_copy(band2gpt_h, band2gpt);
+    auto band_lims_wavenum_h = Kokkos::create_mirror_view_and_copy(DefaultDevice(), band_lims_wavenum);
+    auto band2gpt_h = Kokkos::create_mirror_view_and_copy(DefaultDevice(), band2gpt);
     OpticalPropsK::init(band_lims_wavenum_h, band2gpt_h);
 
     // Which gases known to the gas optics are present in the host model (available_gases)?
@@ -1633,8 +1631,7 @@ public:
       }
     }
     // Allocate class copy, and deep copy to the class data member
-    this->vmr_ref = Kokkos::create_mirror_view(DefaultDevice(), vmr_ref_red);
-    Kokkos::deep_copy(this->vmr_ref, vmr_ref_red);
+    this->vmr_ref = Kokkos::create_mirror_view_and_copy(DefaultDevice(), vmr_ref_red);
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // REDUCE MINOR ARRAYS SO VARIABLES ONLY CONTAIN MINOR GASES THAT ARE AVAILABLE
@@ -1654,17 +1651,11 @@ public:
                         minor_limits_gpt_lower_red, minor_scales_with_density_lower_red, scaling_gas_lower_red,
                         scale_by_complement_lower_red, kminor_start_lower_red);
 
-    this->kminor_lower                    = Kokkos::create_mirror_view(DefaultDevice(), kminor_lower_red);
-    this->minor_limits_gpt_lower          = Kokkos::create_mirror_view(DefaultDevice(), minor_limits_gpt_lower_red);
-    this->minor_scales_with_density_lower = Kokkos::create_mirror_view(DefaultDevice(), minor_scales_with_density_lower_red);
-    this->scale_by_complement_lower       = Kokkos::create_mirror_view(DefaultDevice(), scale_by_complement_lower_red);
-    this->kminor_start_lower              = Kokkos::create_mirror_view(DefaultDevice(), kminor_start_lower_red);
-
-    Kokkos::deep_copy(this->kminor_lower, kminor_lower_red);
-    Kokkos::deep_copy(this->minor_limits_gpt_lower, minor_limits_gpt_lower_red);
-    Kokkos::deep_copy(this->minor_scales_with_density_lower, minor_scales_with_density_lower_red);
-    Kokkos::deep_copy(this->scale_by_complement_lower, scale_by_complement_lower_red);
-    Kokkos::deep_copy(this->kminor_start_lower, kminor_start_lower_red);
+    this->kminor_lower                    = Kokkos::create_mirror_view_and_copy(DefaultDevice(), kminor_lower_red);
+    this->minor_limits_gpt_lower          = Kokkos::create_mirror_view_and_copy(DefaultDevice(), minor_limits_gpt_lower_red);
+    this->minor_scales_with_density_lower = Kokkos::create_mirror_view_and_copy(DefaultDevice(), minor_scales_with_density_lower_red);
+    this->scale_by_complement_lower       = Kokkos::create_mirror_view_and_copy(DefaultDevice(), scale_by_complement_lower_red);
+    this->kminor_start_lower              = Kokkos::create_mirror_view_and_copy(DefaultDevice(), kminor_start_lower_red);
 
     // Find the largest number of g-points per band
     this->max_gpt_diff_lower = std::numeric_limits<int>::lowest();
@@ -1687,17 +1678,11 @@ public:
                         minor_limits_gpt_upper_red, minor_scales_with_density_upper_red, scaling_gas_upper_red,
                         scale_by_complement_upper_red, kminor_start_upper_red);
 
-    this->kminor_upper                    = Kokkos::create_mirror_view(DefaultDevice(), kminor_upper_red);
-    this->minor_limits_gpt_upper          = Kokkos::create_mirror_view(DefaultDevice(), minor_limits_gpt_upper_red);
-    this->minor_scales_with_density_upper = Kokkos::create_mirror_view(DefaultDevice(), minor_scales_with_density_upper_red);
-    this->scale_by_complement_upper       = Kokkos::create_mirror_view(DefaultDevice(), scale_by_complement_upper_red);
-    this->kminor_start_upper              = Kokkos::create_mirror_view(DefaultDevice(), kminor_start_upper_red);
-
-    Kokkos::deep_copy(this->kminor_upper, kminor_upper_red);
-    Kokkos::deep_copy(this->minor_limits_gpt_upper, minor_limits_gpt_upper_red);
-    Kokkos::deep_copy(this->minor_scales_with_density_upper, minor_scales_with_density_upper_red);
-    Kokkos::deep_copy(this->scale_by_complement_upper, scale_by_complement_upper_red);
-    Kokkos::deep_copy(this->kminor_start_upper, kminor_start_upper_red);
+    this->kminor_upper                    = Kokkos::create_mirror_view_and_copy(DefaultDevice(), kminor_upper_red);
+    this->minor_limits_gpt_upper          = Kokkos::create_mirror_view_and_copy(DefaultDevice(), minor_limits_gpt_upper_red);
+    this->minor_scales_with_density_upper = Kokkos::create_mirror_view_and_copy(DefaultDevice(), minor_scales_with_density_upper_red);
+    this->scale_by_complement_upper       = Kokkos::create_mirror_view_and_copy(DefaultDevice(), scale_by_complement_upper_red);
+    this->kminor_start_upper              = Kokkos::create_mirror_view_and_copy(DefaultDevice(), kminor_start_upper_red);
 
     // Find the largest number of g-points per band
     this->max_gpt_diff_upper = std::numeric_limits<int>::lowest();
@@ -1708,12 +1693,9 @@ public:
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // HANDLE ARRAYS NOT REDUCED BY THE PRESENCE, OR LACK THEREOF, OF A GAS
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    this->press_ref = Kokkos::create_mirror_view(DefaultDevice(), press_ref);
-    this->temp_ref  = Kokkos::create_mirror_view(DefaultDevice(), temp_ref);
-    this->kmajor    = Kokkos::create_mirror_view(DefaultDevice(), kmajor);
-    Kokkos::deep_copy(this->press_ref, press_ref);
-    Kokkos::deep_copy(this->temp_ref, temp_ref);
-    Kokkos::deep_copy(this->kmajor, kmajor);
+    this->press_ref = Kokkos::create_mirror_view_and_copy(DefaultDevice(), press_ref);
+    this->temp_ref  = Kokkos::create_mirror_view_and_copy(DefaultDevice(), temp_ref);
+    this->kmajor    = Kokkos::create_mirror_view_and_copy(DefaultDevice(), kmajor);
 
     // Process rayl_lower and rayl_upper into a combined this->krayl
     if (rayl_lower.is_allocated() != rayl_upper.is_allocated()) {
@@ -1729,8 +1711,7 @@ public:
           }
         }
       }
-      this->krayl = Kokkos::create_mirror_view(DefaultDevice(), krayltmp);
-      Kokkos::deep_copy(this->krayl, krayltmp);
+      this->krayl = Kokkos::create_mirror_view_and_copy(DefaultDevice(), krayltmp);
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1753,19 +1734,15 @@ public:
     intHost1dk idx_minor_upper_tmp;
     create_idx_minor(this->gas_names, gas_minor, identifier_minor, minor_gases_lower_red, idx_minor_lower_tmp);
     create_idx_minor(this->gas_names, gas_minor, identifier_minor, minor_gases_upper_red, idx_minor_upper_tmp);
-    this->idx_minor_lower = Kokkos::create_mirror_view(DefaultDevice(), idx_minor_lower_tmp);
-    this->idx_minor_upper = Kokkos::create_mirror_view(DefaultDevice(), idx_minor_upper_tmp);
-    Kokkos::deep_copy(this->idx_minor_lower, idx_minor_lower_tmp);
-    Kokkos::deep_copy(this->idx_minor_upper, idx_minor_upper_tmp);
+    this->idx_minor_lower = Kokkos::create_mirror_view_and_copy(DefaultDevice(), idx_minor_lower_tmp);
+    this->idx_minor_upper = Kokkos::create_mirror_view_and_copy(DefaultDevice(), idx_minor_upper_tmp);
     // Get index of gas (if present) that has special treatment in density scaling
     intHost1dk idx_minor_scaling_lower_tmp;
     intHost1dk idx_minor_scaling_upper_tmp;
     create_idx_minor_scaling(this->gas_names, scaling_gas_lower_red, idx_minor_scaling_lower_tmp);
     create_idx_minor_scaling(this->gas_names, scaling_gas_upper_red, idx_minor_scaling_upper_tmp);
-    this->idx_minor_scaling_lower = Kokkos::create_mirror_view(DefaultDevice(), idx_minor_scaling_lower_tmp);
-    this->idx_minor_scaling_upper = Kokkos::create_mirror_view(DefaultDevice(), idx_minor_scaling_upper_tmp);
-    Kokkos::deep_copy(this->idx_minor_scaling_lower, idx_minor_scaling_lower_tmp);
-    Kokkos::deep_copy(this->idx_minor_scaling_upper, idx_minor_scaling_upper_tmp);
+    this->idx_minor_scaling_lower = Kokkos::create_mirror_view_and_copy(DefaultDevice(), idx_minor_scaling_lower_tmp);
+    this->idx_minor_scaling_upper = Kokkos::create_mirror_view_and_copy(DefaultDevice(), idx_minor_scaling_upper_tmp);
 
     // create flavor list
     // Reduce (remap) key_species list; checks that all key gases are present in incoming
@@ -1775,14 +1752,11 @@ public:
     // create flavor and gpoint_flavor lists
     intHost2dk flavor_tmp;
     intHost2dk gpoint_flavor_tmp;
-    auto gpoint_bands_tmp = Kokkos::create_mirror_view(this->get_gpoint_bands());
-    Kokkos::deep_copy(gpoint_bands_tmp, this->get_gpoint_bands());
+    auto gpoint_bands_tmp = Kokkos::create_mirror_view_and_copy(HostDevice(), this->get_gpoint_bands());
     create_flavor       (key_species_red, flavor_tmp);
     create_gpoint_flavor(key_species_red, gpoint_bands_tmp, flavor_tmp, gpoint_flavor_tmp);
-    this->flavor        = Kokkos::create_mirror_view(DefaultDevice(), flavor_tmp);
-    this->gpoint_flavor = Kokkos::create_mirror_view(DefaultDevice(), gpoint_flavor_tmp);
-    Kokkos::deep_copy(this->flavor, flavor_tmp);
-    Kokkos::deep_copy(this->gpoint_flavor, gpoint_flavor_tmp);
+    this->flavor        = Kokkos::create_mirror_view_and_copy(DefaultDevice(), flavor_tmp);
+    this->gpoint_flavor = Kokkos::create_mirror_view_and_copy(DefaultDevice(), gpoint_flavor_tmp);
 
     // minimum, maximum reference temperature, pressure -- assumes low-to-high ordering
     //   for T, high-to-low ordering for p
@@ -1850,10 +1824,8 @@ public:
                     kminor_start_lower, kminor_start_upper, rayl_lower, rayl_upper);
 
     // Planck function tables
-    this->totplnk = Kokkos::create_mirror_view(DefaultDevice(), totplnk);
-    this->planck_frac = Kokkos::create_mirror_view(DefaultDevice(), planck_frac);
-    Kokkos::deep_copy(this->totplnk, totplnk);
-    Kokkos::deep_copy(this->planck_frac, planck_frac);
+    this->totplnk = Kokkos::create_mirror_view_and_copy(DefaultDevice(), totplnk);
+    this->planck_frac = Kokkos::create_mirror_view_and_copy(DefaultDevice(), planck_frac);
     // Temperature steps for Planck function interpolation
     //   Assumes that temperature minimum and max are the same for the absorption coefficient grid and the
     //   Planck grid and the Planck grid is equally spaced
@@ -1904,8 +1876,7 @@ public:
                     kminor_start_lower, kminor_start_upper, rayl_lower, rayl_upper);
 
     // Solar source table init
-    this->solar_src = Kokkos::create_mirror_view(DefaultDevice(), solar_src);
-    Kokkos::deep_copy(this->solar_src, solar_src);
+    this->solar_src = Kokkos::create_mirror_view_and_copy(DefaultDevice(), solar_src);
     this->totplnk_delta = 0.;
   }
 
@@ -1965,8 +1936,7 @@ public:
   // Ensure that every key gas required by the k-distribution is present in the gas concentration object
   void check_key_species_present(GasConcsK const &gas_desc) const {
     string1dv key_gas_names;
-    auto is_key_h = Kokkos::create_mirror_view(this->is_key);
-    Kokkos::deep_copy(is_key_h, this->is_key);
+    auto is_key_h = Kokkos::create_mirror_view_and_copy(HostDevice(), this->is_key);
     for (auto i = 0; i < is_key_h.extent(0); ++i) {
       if (is_key_h(i)) {
         key_gas_names.push_back(this->gas_names[i]);

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -455,9 +455,9 @@ typename KView::non_const_value_type minval(const KView& view)
   scalar_t rv;
   Kokkos::parallel_reduce(
     Kokkos::RangePolicy<exe_space_t>(0, view.size()),
-    KOKKOS_LAMBDA(size_t i, scalar_t& lmax) {
+    KOKKOS_LAMBDA(size_t i, scalar_t& lmin) {
       const scalar_t val = view.data()[i];
-      if (val > lmax) lmax = val;
+      if (val < lmin) lmin = val;
     }, Kokkos::Min<scalar_t>(rv));
   return rv;
 }

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -1197,6 +1197,66 @@ public:
   }
 };
 
+// Copied with minor modes from YAKL_random.h
+
+class Random {
+ protected:
+  /** @private */
+  typedef unsigned long long u8;
+  /** @private */
+  u8 static constexpr rot(u8 x, u8 k) { return (((x)<<(k))|((x)>>(64-(k)))); }
+  /** @private */
+  struct State { u8 a, b, c, d; };
+  /** @private */
+  State state;
+
+ public:
+
+  /** @brief Initializes a prng object with the seed 1368976481. Warm-up of 20 iterations. */
+  KOKKOS_INLINE_FUNCTION Random()                            { set_seed(1368976481L); } // I made up this number
+  /** @brief Initializes a prng object with the specified seed. Warm-up of 20 iterations. */
+  KOKKOS_INLINE_FUNCTION Random(u8 seed)                     { set_seed(seed); }
+  /** @brief Copies a Random object */
+  KOKKOS_INLINE_FUNCTION Random(Random const            &in) { this->state = in.state; }
+  /** @brief Moves a Random object */
+  KOKKOS_INLINE_FUNCTION Random(Random                 &&in) { this->state = in.state; }
+  /** @brief Copies a Random object */
+  KOKKOS_INLINE_FUNCTION Random &operator=(Random const &in) { this->state = in.state; return *this; }
+  /** @brief Moves a Random object */
+  KOKKOS_INLINE_FUNCTION Random &operator=(Random      &&in) { this->state = in.state; return *this; }
+
+  /** @brief Assigns a seed. Warm-up of 20 iterations. */
+  KOKKOS_INLINE_FUNCTION void set_seed(u8 seed) {
+    state.a = 0xf1ea5eed;  state.b = seed;  state.c = seed;  state.d = seed;
+    for (int i=0; i<20; ++i) { gen(); }
+  }
+
+  /** @brief Generates a random unsigned integer between zero and `std::numeric_limits<u8>::max() - 1` */
+  KOKKOS_INLINE_FUNCTION u8 gen() {
+    u8 e    = state.a - rot(state.b, 7);
+    state.a = state.b ^ rot(state.c,13);
+    state.b = state.c + rot(state.d,37);
+    state.c = state.d + e;
+    state.d = e       + state.a;
+    return state.d;
+  }
+
+  /** @brief Generates a random floating point value between `0` and `1`
+   * @param T The type of the floating point number */
+  template <class T> KOKKOS_INLINE_FUNCTION T genFP() {
+    return static_cast<T>(gen()) / static_cast<T>(std::numeric_limits<u8>::max());
+  }
+
+  /** @brief Generates a random floating point value between `lb` and `ub`
+   * @param T  The type of the floating point number
+   * @param lb Lower bound of the random number
+   * @param ub Upper bound of the random number*/
+  template <class T> KOKKOS_INLINE_FUNCTION T genFP(T lb, T ub) {
+    return genFP<T>() * (ub-lb) + lb;
+  }
+
+};
+
 #endif
 
 }

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -237,6 +237,9 @@ inline
 bool approx_eq<real>(const real lhs, const real rhs)
 {
   constexpr real tol = 1e-12;
+  if (std::isnan(lhs) && std::isnan(rhs)) {
+    return true;
+  }
   return std::abs(lhs - rhs) < tol;
 }
 
@@ -314,6 +317,13 @@ void compare_yakl_to_kokkos(const YArray& yarray, const KView& kview, bool index
   }
   LeftHostView hkview("read_data", llayout);
   Kokkos::deep_copy(hkview, kview);
+
+  RRT_REQUIRE(kview.is_allocated() == yakl::intrinsics::allocated(yarray),
+              "Allocation status mismatch for: " << kview.label());
+  if (!kview.is_allocated()) {
+    // we're done
+    return;
+  }
 
   auto hyarray = yarray.createHostCopy();
 

--- a/cpp/rte/kernels/mo_rte_solver_kernels.cpp
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.cpp
@@ -909,7 +909,7 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, real2dk const &albedo_s
 
       // From bottom to top of atmosphere --
       //   compute albedo and source of upward radiation
-      for (ilev=nlay-1; ilev>0; ilev--) {
+      for (ilev=nlay-1; ilev>=0; ilev--) {
         denom(icol,ilev,igpt) = 1./(1. - rdif(icol,ilev,igpt)*albedo(icol,ilev+1,igpt));    // Eq 10
         albedo(icol,ilev,igpt) = rdif(icol,ilev,igpt) +
                                  tdif(icol,ilev,igpt)*tdif(icol,ilev,igpt) * albedo(icol,ilev+1,igpt) * denom(icol,ilev,igpt); // Equation 9
@@ -927,7 +927,7 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, real2dk const &albedo_s
                                 src(icol,ilev,igpt);                                  // emission from below
 
       // From the top of the atmosphere downward -- compute fluxes
-      for (ilev = 1; ilev < nlay+1; ilev++) {
+      for (ilev = 1; ilev <= nlay; ilev++) {
         flux_dn(icol,ilev,igpt) = (tdif(icol,ilev-1,igpt)*flux_dn(icol,ilev-1,igpt) +   // Equation 13
                                   rdif(icol,ilev-1,igpt)*src(icol,ilev,igpt) +
                                   src_dn(icol,ilev-1,igpt)) * denom(icol,ilev-1,igpt);


### PR DESCRIPTION
1) Bring in load_and_init changes from eamxx for reading solar stuff
2) Use create_mirror_view_and_copy to save some deep_copy calls
3) Port a couple functions to Kokkos that eamxx needs
4) Fix a bug that was causing non-BFB results between YAKL and Kokkos
5) Adds a copy of yakl::Random to conv so we can duplicate random number generation.

I've built this version of rrtmgp against my porting branch for eamxx/rrtmgp and it builds.