### PR TITLE
Tools and Tunings to make Kokkos GPU perf better

### DIFF
--- a/cpp/examples/all-sky/mo_garand_atmos_io.cpp
+++ b/cpp/examples/all-sky/mo_garand_atmos_io.cpp
@@ -24,31 +24,31 @@ void read_atmos(std::string input_file, real2d &p_lay, real2d &t_lay, real2d &p_
   io.read(tmp2d,"p_lay");
   // for (int ilay=1 ; ilay <= nlay ; ilay++) {
   //   for (int icol=1 ; icol <= ncol ; icol++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
     p_lay(icol,ilay) = tmp2d(1,ilay);
-  });
+  }));
   // t_lay
   io.read(tmp2d,"t_lay");
   // for (int ilay=1 ; ilay <= nlay ; ilay++) {
   //   for (int icol=1 ; icol <= ncol ; icol++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA ( int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA ( int ilay, int icol) {
     t_lay(icol,ilay) = tmp2d(1,ilay);
-  });
+  }));
   // p_lev
   tmp2d = real2d();  // Reset tmp2d to avoid warnings about reallocating during file read
   io.read(tmp2d,"p_lev");
   // for (int ilev=1 ; ilev <= nlev ; ilev++) {
   //   for (int icol=1 ; icol <= ncol ; icol++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev,ncol) , YAKL_LAMBDA ( int ilev, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev,ncol) , YAKL_LAMBDA ( int ilev, int icol) {
     p_lev(icol,ilev) = tmp2d(1,ilev);
-  });
+  }));
   // t_lev
   io.read(tmp2d,"t_lev");
   // for (int ilev=1 ; ilev <= nlev ; ilev++) {
   //   for (int icol=1 ; icol <= ncol ; icol++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev,ncol) , YAKL_LAMBDA( int ilev, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev,ncol) , YAKL_LAMBDA( int ilev, int icol) {
     t_lev(icol,ilev) = tmp2d(1,ilev);
-  });
+  }));
 
   std::vector<std::string> gas_names = {
     "h2o", "co2", "o3", "n2o", "co", "ch4", "o2", "n2"
@@ -66,9 +66,9 @@ void read_atmos(std::string input_file, real2d &p_lay, real2d &t_lay, real2d &p_
     // Create 1-D variable with just the first column
     real1d tmp1d("tmp1d",nlay);
     // for (int i=1 ; i <= nlay ; i++) {
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(nlay) , YAKL_LAMBDA (int i) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(nlay) , YAKL_LAMBDA (int i) {
       tmp1d(i) = tmp2d(1,i);
-    });
+    }));
     // Call set_vmr with only the first column from the data file copied among all of the model columns
     gas_concs.set_vmr( gas_name , tmp1d );
   }
@@ -79,9 +79,9 @@ void read_atmos(std::string input_file, real2d &p_lay, real2d &t_lay, real2d &p_
     io.read(tmp2d,"col_dry");
     // for (int ilay=1 ; ilay <= nlay ; ilay++) {
     //   for (int icol=1 ; icol <= ncol ; icol++) {
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA( int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA( int ilay, int icol) {
       col_dry(icol,ilay) = tmp2d(1,ilay);
-    });
+    }));
   }
 
   io.close();

--- a/cpp/examples/all-sky/mo_garand_atmos_io.h
+++ b/cpp/examples/all-sky/mo_garand_atmos_io.h
@@ -39,24 +39,24 @@ void read_atmos(const std::string& input_file, ViewT &p_lay, ViewT &t_lay, ViewT
   ViewT tmp2d;
   // p_lay
   io.read(tmp2d,"p_lay");
-  Kokkos::parallel_for( MDRP::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
     p_lay(icol,ilay) = tmp2d(0,ilay);
-  });
+  }));
   // t_lay
   io.read(tmp2d,"t_lay");
-  Kokkos::parallel_for( MDRP::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
     t_lay(icol,ilay) = tmp2d(0,ilay);
-  });
+  }));
   // p_lev
   io.read(tmp2d,"p_lev");
-  Kokkos::parallel_for( MDRP::template get<2>({nlev,ncol}), KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({nlev,ncol}), KOKKOS_LAMBDA (int ilev, int icol) {
     p_lev(icol,ilev) = tmp2d(0,ilev);
-  });
+  }));
   // t_lev
   io.read(tmp2d,"t_lev");
-  Kokkos::parallel_for( MDRP::template get<2>({nlev,ncol}), KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({nlev,ncol}), KOKKOS_LAMBDA (int ilev, int icol) {
     t_lev(icol,ilev) = tmp2d(0,ilev);
-  });
+  }));
 
   std::vector<std::string> gas_names = {
     "h2o", "co2", "o3", "n2o", "co", "ch4", "o2", "n2"
@@ -73,9 +73,9 @@ void read_atmos(const std::string& input_file, ViewT &p_lay, ViewT &t_lay, ViewT
     io.read(tmp2d,vmr_name);
     // Create 1-D variable with just the first column
     Kokkos::View<RealT*, LayoutT, DeviceT> tmp1d("tmp1d",nlay);
-    Kokkos::parallel_for( nlay, KOKKOS_LAMBDA (int i) {
+    TIMED_KERNEL(Kokkos::parallel_for( nlay, KOKKOS_LAMBDA (int i) {
       tmp1d(i) = tmp2d(0,i);
-    });
+    }));
     // Call set_vmr with only the first column from the data file copied among all of the model columns
     gas_concs.set_vmr( gas_name , tmp1d );
   }
@@ -84,9 +84,9 @@ void read_atmos(const std::string& input_file, ViewT &p_lay, ViewT &t_lay, ViewT
     col_dry = ViewT("col_dry",ncol,nlay);
     tmp2d = ViewT();     // Reset the tmp2d variable
     io.read(tmp2d,"col_dry");
-    Kokkos::parallel_for( MDRP::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
       col_dry(icol,ilay) = tmp2d(0,ilay);
-    });
+    }));
   }
 
   io.close();

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -796,10 +796,10 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // Cloud masks; don't need value re values if there's no cloud
     // do ilay = 1, nlay
     //   do icol = 1, ncol
-    Kokkos::parallel_for( mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
       liqmsk(icol,ilay) = clwp(icol,ilay) > 0.;
       icemsk(icol,ilay) = ciwp(icol,ilay) > 0.;
-    });
+    }));
 
     #ifdef RRTMGP_EXPENSIVE_CHECKS
       // Particle size, liquid/ice water paths
@@ -871,11 +871,11 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1,ncol
-    Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
       // Absorption optical depth  = (1-ssa) * tau = tau - taussa
       optical_props_tau(icol,ilay,ibnd) = (ltau(icol,ilay,ibnd) - ltaussa(icol,ilay,ibnd)) +
                                           (itau(icol,ilay,ibnd) - itaussa(icol,ilay,ibnd));
-    });
+    }));
   }
 
   template <typename LtauT, typename ItauT, typename LtaussaT,
@@ -888,13 +888,13 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1,ncol
-    Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
       RealT tau    = ltau   (icol,ilay,ibnd) + itau   (icol,ilay,ibnd);
       RealT taussa = ltaussa(icol,ilay,ibnd) + itaussa(icol,ilay,ibnd);
       optical_props_g  (icol,ilay,ibnd) = (ltaussag(icol,ilay,ibnd) + itaussag(icol,ilay,ibnd)) / Kokkos::fmax(conv::epsilon(tau), taussa);
       optical_props_ssa(icol,ilay,ibnd) = taussa / Kokkos::fmax(conv::epsilon(tau), tau);
       optical_props_tau(icol,ilay,ibnd) = tau;
-    });
+    }));
   }
 
   void set_ice_roughness(int icergh) {
@@ -931,7 +931,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // do ibnd = 1, nbnd
     //   do ilay = 1,nlay
     //     do icol = 1, ncol
-    Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
       if (mask(icol,ilay)) {
         int index = Kokkos::fmin( floor( (re(icol,ilay) - offset) / step_size)+1, nsteps-1.) - 1;
         RealT fint = (re(icol,ilay) - offset)/step_size - index;
@@ -945,7 +945,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
         taussa (icol,ilay,ibnd) = 0;
         taussag(icol,ilay,ibnd) = 0;
       }
-    });
+    }));
   }
 
   // Pade functions
@@ -959,7 +959,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1, ncol
-    Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
       if (mask(icol,ilay)) {
         int irad;
         // Finds index into size regime table
@@ -982,7 +982,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
         taussa (icol,ilay,ibnd) = 0;
         taussag(icol,ilay,ibnd) = 0;
       }
-    });
+    }));
   }
 
   // Evaluate Pade approximant of order [m/n]

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -266,10 +266,10 @@ public:
     // Cloud masks; don't need value re values if there's no cloud
     // do ilay = 1, nlay
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
       liqmsk(icol,ilay) = clwp(icol,ilay) > 0.;
       icemsk(icol,ilay) = ciwp(icol,ilay) > 0.;
-    });
+    }));
 
     #ifdef RRTMGP_EXPENSIVE_CHECKS
       // Particle size, liquid/ice water paths
@@ -339,11 +339,11 @@ public:
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1,ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlay,ncol) , YAKL_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlay,ncol) , YAKL_LAMBDA (int ibnd, int ilay, int icol) {
       // Absorption optical depth  = (1-ssa) * tau = tau - taussa
       optical_props_tau(icol,ilay,ibnd) = (ltau(icol,ilay,ibnd) - ltaussa(icol,ilay,ibnd)) +
                                           (itau(icol,ilay,ibnd) - itaussa(icol,ilay,ibnd));
-    });
+    }));
   }
 
 
@@ -360,13 +360,13 @@ public:
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1,ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlay,ncol) , YAKL_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlay,ncol) , YAKL_LAMBDA (int ibnd, int ilay, int icol) {
       real tau    = ltau   (icol,ilay,ibnd) + itau   (icol,ilay,ibnd);
       real taussa = ltaussa(icol,ilay,ibnd) + itaussa(icol,ilay,ibnd);
       optical_props_g  (icol,ilay,ibnd) = (ltaussag(icol,ilay,ibnd) + itaussag(icol,ilay,ibnd)) / std::max(epsilon(tau), taussa);
       optical_props_ssa(icol,ilay,ibnd) = taussa / std::max(epsilon(tau), tau);
       optical_props_tau(icol,ilay,ibnd) = tau;
-    });
+    }));
   }
 
 
@@ -426,7 +426,7 @@ public:
     // do ibnd = 1, nbnd
     //   do ilay = 1,nlay
     //     do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlay,ncol) , YAKL_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlay,ncol) , YAKL_LAMBDA (int ibnd, int ilay, int icol) {
       if (mask(icol,ilay)) {
         int index = std::min( floor( (re(icol,ilay) - offset) / step_size)+1, nsteps-1.);
         real fint = (re(icol,ilay) - offset)/step_size - (index-1);
@@ -440,7 +440,7 @@ public:
         taussa (icol,ilay,ibnd) = 0;
         taussag(icol,ilay,ibnd) = 0;
       }
-    });
+    }));
   }
 
 
@@ -457,7 +457,7 @@ public:
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlay,ncol) , YAKL_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlay,ncol) , YAKL_LAMBDA (int ibnd, int ilay, int icol) {
       if (mask(icol,ilay)) {
         int irad;
         // Finds index into size regime table
@@ -480,7 +480,7 @@ public:
         taussa (icol,ilay,ibnd) = 0;
         taussag(icol,ilay,ibnd) = 0;
       }
-    });
+    }));
   }
 
 

--- a/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.cpp
+++ b/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.cpp
@@ -6,22 +6,22 @@ void sum_byband(int ncol, int nlev, int ngpt, int nbnd, int2d const &bnd_lims, r
   using yakl::fortran::parallel_for;
   using yakl::fortran::SimpleBounds;
 
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlev,ncol) , YAKL_LAMBDA (int ibnd, int ilev, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlev,ncol) , YAKL_LAMBDA (int ibnd, int ilev, int icol) {
     real bb_flux_s = 0.0;
     for (int igpt=bnd_lims(1,ibnd); igpt<=bnd_lims(2,ibnd); igpt++) {
       bb_flux_s += spectral_flux(icol,ilev,igpt);
     }
     byband_flux(icol,ilev,ibnd) = bb_flux_s;
-  });
+  }));
 }
 // Compute net flux
 void net_byband(int ncol, int nlev, int nbnd, real3d const &bnd_flux_dn, real3d const &bnd_flux_up, real3d &bnd_flux_net) {
   using yakl::fortran::parallel_for;
   using yakl::fortran::SimpleBounds;
 
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlev,ncol), YAKL_LAMBDA(int ibnd, int ilev, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nbnd,nlev,ncol), YAKL_LAMBDA(int ibnd, int ilev, int icol) {
       bnd_flux_net(icol,ilev,ibnd) = bnd_flux_dn(icol,ilev,ibnd) - bnd_flux_up(icol,ilev,ibnd);
-  });
+  }));
 }
 #endif
 

--- a/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.h
+++ b/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.h
@@ -17,13 +17,13 @@ void sum_byband(int ncol, int nlev, int ngpt, int nbnd, BndLimsT const &bnd_lims
   using LayoutT = typename SpectralT::array_layout;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
-  Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlev,ncol}) , KOKKOS_LAMBDA (int ibnd, int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlev,ncol}) , KOKKOS_LAMBDA (int ibnd, int ilev, int icol) {
     RealT bb_flux_s = 0.0;
     for (int igpt=bnd_lims(0,ibnd); igpt<=bnd_lims(1,ibnd); igpt++) {
       bb_flux_s += spectral_flux(icol,ilev,igpt);
     }
     byband_flux(icol,ilev,ibnd) = bb_flux_s;
-  });
+  }));
 }
 // Compute net flux
 template <typename FluxDnT, typename FluxUpT, typename FluxNetT>
@@ -33,8 +33,8 @@ void net_byband(int ncol, int nlev, int nbnd,
   using LayoutT = typename FluxDnT::array_layout;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
-  Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlev,ncol}) , KOKKOS_LAMBDA (int ibnd, int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlev,ncol}) , KOKKOS_LAMBDA (int ibnd, int ilev, int icol) {
       bnd_flux_net(icol,ilev,ibnd) = bnd_flux_dn(icol,ilev,ibnd) - bnd_flux_up(icol,ilev,ibnd);
-  });
+  }));
 }
 #endif

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp
@@ -18,7 +18,7 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
 
   // for (int ilay=1; ilay<=nlay; ilay++) {
   //   for (int icol=1; icol<=ncol; icol++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
     // index and factor for temperature interpolation
     jtemp(icol,ilay) = (int) ((tlay(icol,ilay) - (temp_ref_min - temp_ref_delta)) / temp_ref_delta);
     jtemp(icol,ilay) = std::min(ntemp - 1, std::max(1, jtemp(icol,ilay))); // limit the index range
@@ -31,13 +31,13 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
 
     // determine if in lower or upper part of atmosphere
     tropo(icol,ilay) = log(play(icol,ilay)) > press_ref_trop_log;
-  });
+  }));
 
   // for (int ilay=1; ilay<=nlay; ilay++) {
   //   for (int icol=1; icol<=ncol; icol++) {
   //     for (int iflav=1; iflav<=nflav; iflav++) {   // loop over implemented combinations of major species
   //       for (int itemp=1; itemp<=2; itemp++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<4>(nlay,ncol,nflav,2) , YAKL_LAMBDA (int ilay, int icol, int iflav , int itemp) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<4>(nlay,ncol,nflav,2) , YAKL_LAMBDA (int ilay, int icol, int iflav , int itemp) {
     yakl::FSArray<int,1,SB<2>> igases;
 
     // itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
@@ -65,7 +65,7 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
     fmajor(2,1,itemp,iflav,icol,ilay) = (1. - fpress(icol,ilay)) * fminor(2,itemp,iflav,icol,ilay);
     fmajor(1,2,itemp,iflav,icol,ilay) =       fpress(icol,ilay)  * fminor(1,itemp,iflav,icol,ilay);
     fmajor(2,2,itemp,iflav,icol,ilay) =       fpress(icol,ilay)  * fminor(2,itemp,iflav,icol,ilay);
-  });
+  }));
 }
 
 
@@ -86,7 +86,7 @@ void combine_and_reorder_2str(int ncol, int nlay, int ngpt, real3d const &tau_ab
   //     for (int tgpt=1; tgpt<=gptTiles; tgpt++) {
   //       for (int itcol=1; itcol<=TILE_SIZE; itcol++) {
   //         for (int itgpt=1; itgpt<=TILE_SIZE; itgpt++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<5>(nlay,colTiles,gptTiles,TILE_SIZE,TILE_SIZE) , YAKL_LAMBDA (int ilay, int tcol, int tgpt, int itcol, int itgpt) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<5>(nlay,colTiles,gptTiles,TILE_SIZE,TILE_SIZE) , YAKL_LAMBDA (int ilay, int tcol, int tgpt, int itcol, int itgpt) {
     int icol = (tcol-1)*TILE_SIZE + itcol;
     int igpt = (tgpt-1)*TILE_SIZE + itgpt;
 
@@ -100,7 +100,7 @@ void combine_and_reorder_2str(int ncol, int nlay, int ngpt, real3d const &tau_ab
         ssa(icol,ilay,igpt) = 0.;
       }
     }
-  });
+  }));
 }
 
 
@@ -128,7 +128,7 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   // for (int icol=1; icol<=ncol; icol++) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nlay,ncol,ngpt) , YAKL_LAMBDA (int ilay, int icol, int igpt) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nlay,ncol,ngpt) , YAKL_LAMBDA (int ilay, int icol, int igpt) {
     // itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
     int itropo = merge(1,2,tropo(icol,ilay));  //WS moved itropo inside loop for GPU
     int iflav = gpoint_flavor(itropo, igpt); //eta interpolation depends on band's flavor
@@ -145,31 +145,31 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
                               fmajor(2,1,2,iflav,icol,ilay) * pfracin(igpt, jeta(2,iflav,icol,ilay)+1, jpress_loc-1, jtemp_loc+1) +
                               fmajor(1,2,2,iflav,icol,ilay) * pfracin(igpt, jeta(2,iflav,icol,ilay)  , jpress_loc  , jtemp_loc+1) +
                               fmajor(2,2,2,iflav,icol,ilay) * pfracin(igpt, jeta(2,iflav,icol,ilay)+1, jpress_loc  , jtemp_loc+1) );
-  });
+  }));
 
   //
   // Planck function by band for the surface
   // Compute surface source irradiance for g-point, equals band irradiance x fraction for g-point
   //
   // for (int icol=1; icol<=ncol; icol++) {
-  parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA (int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA (int icol) {
     interpolate1D(tsfc(icol), temp_ref_min, totplnk_delta, totplnk, planck_function.slice<1>(COLON,1,icol),nPlanckTemp,nbnd);
-  });
+  }));
   //
   // Map to g-points
   //
   // for (int igpt=1; igpt<=ngpt; igpt++) {
   //   for (int icol=1; icol<=ncol; icol++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
     sfc_src(igpt,icol) = pfrac(igpt,sfc_lay,icol) * planck_function(gpoint_bands(igpt), 1, icol);
-  });
+  }));
 
   // for (int icol=1; icol<=ncol; icol++) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ncol,nlay) , YAKL_LAMBDA (int icol, int ilay) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ncol,nlay) , YAKL_LAMBDA (int icol, int ilay) {
     // Compute layer source irradiance for g-point, equals band irradiance x fraction for g-point
     interpolate1D(tlay(icol,ilay), temp_ref_min, totplnk_delta, totplnk, planck_function.slice<1>(COLON,ilay,icol),nPlanckTemp,nbnd);
-  });
+  }));
   //
   // Map to g-points
   //
@@ -179,21 +179,21 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   // for (int icol=1; icol<=ncol; icol++) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ncol,nlay,ngpt) , YAKL_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ncol,nlay,ngpt) , YAKL_LAMBDA (int icol, int ilay, int igpt) {
     lay_src(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay,icol);
-  });
+  }));
 
   // compute level source irradiances for each g-point, one each for upward and downward paths
   // for (int icol=1; icol<=ncol; icol++) {
-  parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA (int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA (int icol) {
     interpolate1D(tlev(icol,1), temp_ref_min, totplnk_delta, totplnk, planck_function.slice<1>(COLON,1,icol),nPlanckTemp,nbnd);
-  });
+  }));
 
   // for (int icol=1; icol<=ncol; icol++) {
   //   for (int ilay=2; ilay<=nlay+1; ilay++) {
-  parallel_for( YAKL_AUTO_LABEL() , Bounds<2>(ncol,{2,nlay+1}) , YAKL_LAMBDA (int icol, int ilay) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<2>(ncol,{2,nlay+1}) , YAKL_LAMBDA (int icol, int ilay) {
     interpolate1D(tlev(icol,ilay), temp_ref_min, totplnk_delta, totplnk, planck_function.slice<1>(COLON,ilay,icol),nPlanckTemp,nbnd);
-  });
+  }));
 
   //
   // Map to g-points
@@ -203,14 +203,14 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   // for (int icol=1; icol<=ncol; icol+=2) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ncol,nlay,ngpt) , YAKL_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ncol,nlay,ngpt) , YAKL_LAMBDA (int icol, int ilay, int igpt) {
     lev_src_dec(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay,  icol  );
     lev_src_inc(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay+1,icol  );
     if (icol < ncol) {
       lev_src_dec(igpt,ilay,icol+1) = pfrac(igpt,ilay,icol+1) * planck_function(gpoint_bands(igpt),ilay,  icol+1);
       lev_src_inc(igpt,ilay,icol+1) = pfrac(igpt,ilay,icol+1) * planck_function(gpoint_bands(igpt),ilay+1,icol+1);
     }
-  });
+  }));
 
   auto stop_t = std::chrono::high_resolution_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t);
@@ -233,7 +233,7 @@ void compute_tau_rayleigh(int ncol, int nlay, int nbnd, int ngpt, int ngas, int 
   // for (int ilay=1; ilay<=nlay; ilay++) {
   //   for (int icol=1; icol<=ncol; icol++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nlay,ncol,ngpt) , YAKL_LAMBDA (int ilay, int icol, int igpt) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nlay,ncol,ngpt) , YAKL_LAMBDA (int ilay, int icol, int igpt) {
     int itropo = merge(1,2,tropo(icol,ilay)); // itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
     int iflav = gpoint_flavor(itropo, igpt);
     // Inlining interpolate2D
@@ -242,7 +242,7 @@ void compute_tau_rayleigh(int ncol, int nlay, int nbnd, int ngpt, int ngas, int 
              fminor(1,2,iflav,icol,ilay) * krayl(igpt, jeta(2,iflav,icol,ilay)  , jtemp(icol,ilay)+1,itropo) +
              fminor(2,2,iflav,icol,ilay) * krayl(igpt, jeta(2,iflav,icol,ilay)+1, jtemp(icol,ilay)+1,itropo);
     tau_rayleigh(igpt,ilay,icol) =  k * (col_gas(icol,ilay,idx_h2o)+col_dry(icol,ilay));
-  });
+  }));
 }
 
 
@@ -343,7 +343,7 @@ void compute_tau_rayleigh(int ncol, int nlay, int nbnd, int ngpt, int ngas, int 
     // for (int ilay=1; ilay<=nlay; ilay++) {
     //   for (int icol=1; icol<=ncol; icol++) {
     //     for (int igpt0=0; igpt0<=max_gpt_diff; igpt0++) {
-    parallel_for( YAKL_AUTO_LABEL() , Bounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
       // This check skips individual columns with no pressures in range
       if ( layer_limits(icol,1) <= 0 || ilay < layer_limits(icol,1) || ilay > layer_limits(icol,2) ) {
       } else {
@@ -391,7 +391,7 @@ void compute_tau_rayleigh(int ncol, int nlay, int nbnd, int ngpt, int ngas, int 
           }
         }
       }
-    });
+    }));
   }
 
 #endif
@@ -411,7 +411,7 @@ void gas_optical_depths_major(int ncol, int nlay, int nbnd, int ngpt, int nflav,
   //   for (int icol=1; icol<=ncol; icol++) {
   //     // optical depth calculation for major species
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nlay,ncol,ngpt) , YAKL_LAMBDA (int ilay, int icol, int igpt) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(nlay,ncol,ngpt) , YAKL_LAMBDA (int ilay, int icol, int igpt) {
     // itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
     int itropo = merge(1,2,tropo(icol,ilay));  // WS: moved inside innermost loop
 
@@ -432,7 +432,7 @@ void gas_optical_depths_major(int ncol, int nlay, int nbnd, int ngpt, int nflav,
                                                     fmajor(2,2,2,iflav,icol,ilay) * kmajor(igpt, jeta(2,iflav,icol,ilay)+1, jpress_loc  , jtemp_loc+1) );
 
     tau(igpt,ilay,icol) += tau_major;
-   });
+   }));
 }
 
 
@@ -461,7 +461,7 @@ void compute_tau_absorption(int max_gpt_diff_lower, int max_gpt_diff_upper, int 
   if (top_at_1) {
 
     // for (int icol=1; icol<=ncol; icol++){
-    parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA (int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA (int icol) {
       itropo_lower(icol,2) = nlay;
       // itropo_lower(icol,1) = minloc(play(icol,:), dim=1, mask=tropo(icol,:))
       {
@@ -493,12 +493,12 @@ void compute_tau_absorption(int max_gpt_diff_lower, int max_gpt_diff_upper, int 
         }
         itropo_upper(icol,2) = maxloc;
       }
-    });
+    }));
 
   } else {  // top_at_1
 
     // for (int icol=1; icol<=ncol; icol++){
-    parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA ( int icol ) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA ( int icol ) {
       itropo_lower(icol,1) = 1;
       // itropo_lower(icol,2) = minloc(play(icol,:), dim=1, mask=tropo(icol,:))
       {
@@ -531,7 +531,7 @@ void compute_tau_absorption(int max_gpt_diff_lower, int max_gpt_diff_upper, int 
         itropo_upper(icol,1) = maxloc;
       }
 
-    });
+    }));
 
   }  // top_at_1
 
@@ -573,7 +573,7 @@ void combine_and_reorder_nstr(int ncol, int nlay, int ngpt, int nmom, real3d con
   // do icol = 1, ncol
   //   do ilay = 1, nlay
   //     do igpt = 1, ngpt
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ncol,nlay,ngpt) , YAKL_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ncol,nlay,ngpt) , YAKL_LAMBDA (int icol, int ilay, int igpt) {
     real t = tau_abs(igpt,ilay,icol) + tau_rayleigh(igpt,ilay,icol);
     tau(icol,ilay,igpt) = t;
     if (t > 2. * tiny) {
@@ -587,6 +587,6 @@ void combine_and_reorder_nstr(int ncol, int nlay, int ngpt, int nmom, real3d con
     if (nmom >= 2) {
       p(icol,ilay,igpt,2) = 0.1;
     }
-  });
+  }));
 }
 #endif

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp
@@ -117,8 +117,6 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   using yakl::fortran::SimpleBounds;
   using yakl::fortran::Bounds;
 
-  auto start_t = std::chrono::high_resolution_clock::now();
-
   real3d pfrac          ("pfrac"          ,ngpt,nlay,ncol);
   real3d planck_function("planck_function",nbnd,nlay+1,ncol);
   real1d one            ("one"            ,2);
@@ -211,15 +209,7 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
       lev_src_inc(igpt,ilay,icol+1) = pfrac(igpt,ilay,icol+1) * planck_function(gpoint_bands(igpt),ilay+1,icol+1);
     }
   }));
-
-  auto stop_t = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t);
-  static double total_time = 0.0;
-  total_time += (duration.count() / 1000000.0);
-  std::cout << "Total time spent: " << total_time << std::endl;
 }
-
-
 
 // compute Rayleigh scattering optical depths
 void compute_tau_rayleigh(int ncol, int nlay, int nbnd, int ngpt, int ngas, int nflav, int neta, int npres, int ntemp,
@@ -244,8 +234,6 @@ void compute_tau_rayleigh(int ncol, int nlay, int nbnd, int ngpt, int ngas, int 
     tau_rayleigh(igpt,ilay,icol) =  k * (col_gas(icol,ilay,idx_h2o)+col_dry(icol,ilay));
   }));
 }
-
-
 
 // compute minor species optical depths
 #ifdef RRTMGP_CPU_KERNELS

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp
@@ -117,6 +117,8 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   using yakl::fortran::SimpleBounds;
   using yakl::fortran::Bounds;
 
+  auto start_t = std::chrono::high_resolution_clock::now();
+
   real3d pfrac          ("pfrac"          ,ngpt,nlay,ncol);
   real3d planck_function("planck_function",nbnd,nlay+1,ncol);
   real1d one            ("one"            ,2);
@@ -209,6 +211,12 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
       lev_src_inc(igpt,ilay,icol+1) = pfrac(igpt,ilay,icol+1) * planck_function(gpoint_bands(igpt),ilay+1,icol+1);
     }
   });
+
+  auto stop_t = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t);
+  static double total_time = 0.0;
+  total_time += (duration.count() / 1000000.0);
+  std::cout << "Total time spent: " << total_time << std::endl;
 }
 
 

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -405,10 +405,10 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   // for (int icol=1; icol<=ncol; icol+=2) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  TIMED_KERNEL(Kokkos::parallel_for( dims3_tot , KOKKOS_LAMBDA (int idx) {
-    int igpt, ilay, icol;
-    conv::unflatten_idx_left(idx, dims3_ngpt_nlay_ncol, igpt, ilay, icol);
-  // TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  // TIMED_KERNEL(Kokkos::parallel_for( dims3_tot , KOKKOS_LAMBDA (int idx) {
+  //   int igpt, ilay, icol;
+  //   conv::unflatten_idx_right(idx, dims3_ngpt_nlay_ncol, igpt, ilay, icol);
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
     lev_src_dec(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay,  icol  );
     lev_src_inc(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay+1,icol  );
     if (icol < ncol-1) {
@@ -478,9 +478,6 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
   //   for (int icol=1; icol<=ncol; icol++) {
   //     for (int igpt0=0; igpt0<=max_gpt_diff; igpt0++) {
   TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getlr<2>({ncol,nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
-        //TIMED_KERNEL(Kokkos::parallel_for( dims2_ncol_nlay_tot , KOKKOS_LAMBDA (int idx) {
-        //int icol, ilay;
-        //conv::unflatten_idx_right(idx, dims2_ncol_nlay, icol, ilay);
     // This check skips individual columns with no pressures in range
     if ( layer_limits(icol,0) <= -1 || ilay < layer_limits(icol,0) || ilay > layer_limits(icol,1) ) {
     } else {

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -562,8 +562,11 @@ void gas_optical_depths_major(int ncol, int nlay, int nbnd, int ngpt, int nflav,
   //   for (int icol=1; icol<=ncol; icol++) {
   //     // optical depth calculation for major species
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nlay,ncol,ngpt}) , KOKKOS_LAMBDA (int ilay, int icol, int igpt) {
-    // itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
+  Kokkos::Array<int, 3> dims3_ngpt_ncol_nlay = {ngpt,ncol,nlay};
+  const int dims3_tot = ngpt*ncol*nlay;;
+  TIMED_KERNEL(Kokkos::parallel_for(dims3_tot, KOKKOS_LAMBDA (int idx) {
+    int igpt, icol, ilay;
+    conv::unflatten_idx_left(idx, dims3_ngpt_ncol_nlay, igpt, icol, ilay);
     int itropo = merge(0,1,tropo(icol,ilay));  // WS: moved inside innermost loop
 
     // binary species parameter (eta) and col_mix depend on band flavor

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -292,8 +292,6 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
 
   using ureal3d_t = conv::Unmanaged<Kokkos::View<RealT***, LayoutT, DeviceT>>;
 
-  auto start_t = std::chrono::high_resolution_clock::now();
-
   const int dsize1 = ngpt*nlay*ncol;
   const int dsize2 = ngpt*(nlay+1)*ncol;
   RealT* data = pool::template alloc_raw<RealT>(dsize1 + dsize2), *dcurr = data;
@@ -419,12 +417,6 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   }));
 
   pool::dealloc(data, dcurr - data);
-
-  auto stop_t = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t);
-  static double total_time = 0.0;
-  total_time += (duration.count() / 1000000.0);
-  std::cout << "Total time spent: " << total_time << std::endl;
 }
 
 // compute Rayleigh scattering optical depths

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -405,10 +405,13 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   // for (int icol=1; icol<=ncol; icol+=2) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  // TIMED_KERNEL(Kokkos::parallel_for( dims3_tot , KOKKOS_LAMBDA (int idx) {
-  //   int igpt, ilay, icol;
-  //   conv::unflatten_idx_right(idx, dims3_ngpt_nlay_ncol, igpt, ilay, icol);
+#ifdef KOKKOS_ENABLE_CUDA
   TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+#else
+  TIMED_KERNEL(Kokkos::parallel_for( dims3_tot , KOKKOS_LAMBDA (int idx) {
+    int igpt, ilay, icol;
+    conv::unflatten_idx_left(idx, dims3_ngpt_nlay_ncol, igpt, ilay, icol);
+#endif
     lev_src_dec(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay,  icol  );
     lev_src_inc(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay+1,icol  );
     if (icol < ncol-1) {

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -258,19 +258,17 @@ void combine_and_reorder_2str(int ncol, int nlay, int ngpt, TauAbsT const &tau_a
   //     for (int tgpt=1; tgpt<=gptTiles; tgpt++) {
   //       for (int itcol=1; itcol<=TILE_SIZE; itcol++) {
   //         for (int itgpt=1; itgpt<=TILE_SIZE; itgpt++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<5>({nlay,colTiles,gptTiles,TILE_SIZE,TILE_SIZE}) , KOKKOS_LAMBDA (int ilay, int tcol, int tgpt, int itcol, int itgpt) {
-    int icol = tcol*TILE_SIZE + itcol;
-    int igpt = tgpt*TILE_SIZE + itgpt;
-
-    if ( icol < ncol && igpt < ngpt ) {
-      RealT t = tau_abs(igpt,ilay,icol) + tau_rayleigh(igpt,ilay,icol);
-      tau(icol,ilay,igpt) = t;
-      g  (icol,ilay,igpt) = 0.;
-      if(t > 2. * tiny) {
-        ssa(icol,ilay,igpt) = tau_rayleigh(igpt,ilay,icol) / t;
-      } else {
-        ssa(icol,ilay,igpt) = 0.;
-      }
+  // TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<5>({nlay,colTiles,gptTiles,TILE_SIZE,TILE_SIZE}) , KOKKOS_LAMBDA (int ilay, int tcol, int tgpt, int itcol, int itgpt) {
+  //   int icol = tcol*TILE_SIZE + itcol;
+  //   int igpt = tgpt*TILE_SIZE + itgpt;
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+    RealT t = tau_abs(igpt,ilay,icol) + tau_rayleigh(igpt,ilay,icol);
+    tau(icol,ilay,igpt) = t;
+    g  (icol,ilay,igpt) = 0.;
+    if(t > 2. * tiny) {
+      ssa(icol,ilay,igpt) = tau_rayleigh(igpt,ilay,icol) / t;
+    } else {
+      ssa(icol,ilay,igpt) = 0.;
     }
   }));
 }

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -311,7 +311,7 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   // TIMED_KERNEL(Kokkos::parallel_for( dims3_tot, KOKKOS_LAMBDA (int idx) {
   //   int ilay, icol, igpt;
   //   conv::unflatten_idx(idx, dims3_nlay_ncol_ngpt, ilay, icol, igpt);
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nlay,ncol,ngpt}) , KOKKOS_LAMBDA (int ilay, int icol, int igpt) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,ncol,nlay}) , KOKKOS_LAMBDA (int igpt, int icol, int ilay) {
     // itropo = 0 lower atmosphere; itropo = 1 upper atmosphere
     int itropo = merge(0,1,tropo(icol,ilay));  //WS moved itropo inside loop for GPU
     int iflav = gpoint_flavor(itropo, igpt); //eta interpolation depends on band's flavor
@@ -405,10 +405,10 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   // for (int icol=1; icol<=ncol; icol+=2) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  // TIMED_KERNEL(Kokkos::parallel_for( dims3_tot , KOKKOS_LAMBDA (int idx) {
-  //   int igpt, ilay, icol;
-  //   conv::unflatten_idx(idx, dims3_ngpt_nlay_ncol, igpt, ilay, icol);
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( dims3_tot , KOKKOS_LAMBDA (int idx) {
+    int igpt, ilay, icol;
+    conv::unflatten_idx_left(idx, dims3_ngpt_nlay_ncol, igpt, ilay, icol);
+  // TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
     lev_src_dec(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay,  icol  );
     lev_src_inc(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay+1,icol  );
     if (icol < ncol-1) {

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -443,7 +443,7 @@ void compute_tau_rayleigh(int ncol, int nlay, int nbnd, int ngpt, int ngas, int 
   // for (int ilay=1; ilay<=nlay; ilay++) {
   //   for (int icol=1; icol<=ncol; icol++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nlay,ncol,ngpt}) , KOKKOS_LAMBDA (int ilay, int icol, int igpt) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ngpt,ncol,nlay}) , KOKKOS_LAMBDA (int igpt, int icol, int ilay) {
     int itropo = merge(0,1,tropo(icol,ilay)); // itropo = 0 lower atmosphere; itropo = 1 upper atmosphere
     int iflav = gpoint_flavor(itropo, igpt);
     // Inlining interpolate2D

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -477,10 +477,10 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
   // for (int ilay=1; ilay<=nlay; ilay++) {
   //   for (int icol=1; icol<=ncol; icol++) {
   //     for (int igpt0=0; igpt0<=max_gpt_diff; igpt0++) {
-  //TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
-  TIMED_KERNEL(Kokkos::parallel_for( dims2_ncol_nlay_tot , KOKKOS_LAMBDA (int idx) {
-    int icol, ilay;
-    conv::unflatten_idx_right(idx, dims2_ncol_nlay, icol, ilay);
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getlr<2>({ncol,nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
+        //TIMED_KERNEL(Kokkos::parallel_for( dims2_ncol_nlay_tot , KOKKOS_LAMBDA (int idx) {
+        //int icol, ilay;
+        //conv::unflatten_idx_right(idx, dims2_ncol_nlay, icol, ilay);
     // This check skips individual columns with no pressures in range
     if ( layer_limits(icol,0) <= -1 || ilay < layer_limits(icol,0) || ilay > layer_limits(icol,1) ) {
     } else {

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -208,7 +208,7 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
     tropo(icol,ilay) = log(play(icol,ilay)) > press_ref_trop_log;
   }));
 
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<4>({nlay,ncol,nflav,2}) , KOKKOS_LAMBDA (int ilay, int icol, int iflav , int itemp) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<4>({2,nflav,ncol,nlay}) , KOKKOS_LAMBDA (int itemp, int iflav, int icol , int ilay) {
     // itropo = 0 lower atmosphere; itropo = 1 upper atmosphere
     int itropo = merge(0,1,tropo(icol,ilay));
     auto igases1 = flavor(0,iflav);

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -480,7 +480,11 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
   // for (int ilay=1; ilay<=nlay; ilay++) {
   //   for (int icol=1; icol<=ncol; icol++) {
   //     for (int igpt0=0; igpt0<=max_gpt_diff; igpt0++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,extent}) , KOKKOS_LAMBDA (int icol, int ilay, int imnr) {
+#ifdef KOKKOS_ENABLE_CUDA
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getlr<3>({ncol,nlay,extent}) , KOKKOS_LAMBDA (int icol, int ilay, int imnr) {
+#else
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getlr<2>({ncol,nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
+#endif
     // This check skips individual columns with no pressures in range
     if ( layer_limits(icol,0) <= -1 || ilay < layer_limits(icol,0) || ilay > layer_limits(icol,1) ) {
     } else {
@@ -490,6 +494,9 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
       RealT mycol_gas_h2o = col_gas(icol,ilay,idx_h2o);
       RealT mycol_gas_0   = col_gas(icol,ilay,-1);
 
+#ifndef KOKKOS_ENABLE_CUDA
+      for (int imnr=0; imnr<extent; imnr++) {
+#endif
       RealT scaling = col_gas(icol,ilay,idx_minor(imnr));
       if (minor_scales_with_density(imnr)) {
         // NOTE: P needed in hPa to properly handle density scaling.
@@ -524,8 +531,15 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
           fminor(0,1,iflav,icol,ilay) * kminor(minor_loc, jeta(1,iflav,icol,ilay)  , myjtemp+1) +
           fminor(1,1,iflav,icol,ilay) * kminor(minor_loc, jeta(1,iflav,icol,ilay)+1, myjtemp+1);
         RealT tau_minor = kminor_loc * scaling;
+#ifdef KOKKOS_ENABLE_CUDA
         Kokkos::atomic_add(&tau(igpt,ilay,icol), tau_minor);
+#else
+        tau(igpt,ilay,icol) += tau_minor;
+#endif
       }
+#ifndef KOKKOS_ENABLE_CUDA
+      }
+#endif
     }
   }));
 }

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -471,10 +471,16 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
 
   int extent = scale_by_complement.extent(0);
 
+  Kokkos::Array<int, 2> dims2_ncol_nlay = {ncol,nlay};
+  const int dims2_ncol_nlay_tot = ncol * nlay;
+
   // for (int ilay=1; ilay<=nlay; ilay++) {
   //   for (int icol=1; icol<=ncol; icol++) {
   //     for (int igpt0=0; igpt0<=max_gpt_diff; igpt0++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlay,ncol}) , KOKKOS_LAMBDA (int ilay, int icol) {
+  //TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
+  TIMED_KERNEL(Kokkos::parallel_for( dims2_ncol_nlay_tot , KOKKOS_LAMBDA (int idx) {
+    int icol, ilay;
+    conv::unflatten_idx_right(idx, dims2_ncol_nlay, icol, ilay);
     // This check skips individual columns with no pressures in range
     if ( layer_limits(icol,0) <= -1 || ilay < layer_limits(icol,0) || ilay > layer_limits(icol,1) ) {
     } else {

--- a/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
@@ -57,13 +57,13 @@ inline void reorder_123x321_kernel(int d1, int d2, int d3, ArrayInT const &array
   //     for (int t1=1; t1<=ntiles1; t1++) {
   //       for (int it3=1; it3<=TILE_SIZE; it3++) {
   //         for (int it1=1; it1<=TILE_SIZE; it1++) {
-  Kokkos::parallel_for( mdrp_t::template get<5>({d2,ntiles1,ntiles3,TILE_SIZE,TILE_SIZE}) , KOKKOS_LAMBDA (int i2, int t1, int t3, int it1, int it3) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<5>({d2,ntiles1,ntiles3,TILE_SIZE,TILE_SIZE}) , KOKKOS_LAMBDA (int i2, int t1, int t3, int it1, int it3) {
     int i3 = t3*TILE_SIZE + it3;
     int i1 = t1*TILE_SIZE + it1;
     if (i3 < d3 && i1 < d1) {
       array_out(i3,i2,i1) = array_in(i1,i2,i3);
     }
-  });
+  }));
 }
 
 template <typename ArrayInT, typename ArrayOutT>
@@ -75,8 +75,8 @@ inline void reorder_123x312_kernel(int d1, int d2, int d3, ArrayInT const &array
   // do i3 = 1 , d3
   //   do i2 = 1 , d2
   //     do i1 = 1 , d1
-  Kokkos::parallel_for( mdrp_t::template get<3>({d3,d2,d1}) , KOKKOS_LAMBDA (int i3, int i2, int i1) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({d3,d2,d1}) , KOKKOS_LAMBDA (int i3, int i2, int i1) {
     array_out(i3,i1,i2) = array_in(i1,i2,i3);
-  });
+  }));
 }
 #endif

--- a/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
@@ -18,13 +18,13 @@ inline void reorder_123x321_kernel(int d1, int d2, int d3, real3d const &array_i
   //     for (int t1=1; t1<=ntiles1; t1++) {
   //       for (int it3=1; it3<=TILE_SIZE; it3++) {
   //         for (int it1=1; it1<=TILE_SIZE; it1++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<5>(d2,ntiles1,ntiles3,TILE_SIZE,TILE_SIZE) , YAKL_LAMBDA (int i2, int t1, int t3, int it1, int it3) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<5>(d2,ntiles1,ntiles3,TILE_SIZE,TILE_SIZE) , YAKL_LAMBDA (int i2, int t1, int t3, int it1, int it3) {
     int i3 = (t3-1)*TILE_SIZE + it3;
     int i1 = (t1-1)*TILE_SIZE + it1;
     if (i3 <= d3 && i1 <= d1) {
       array_out(i3,i2,i1) = array_in(i1,i2,i3);
     }
-  });
+  }));
 }
 
 
@@ -35,9 +35,9 @@ inline void reorder_123x312_kernel(int d1, int d2, int d3, real3d const &array_i
   // do i3 = 1 , d3
   //   do i2 = 1 , d2
   //     do i1 = 1 , d1
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(d3,d2,d1) , YAKL_LAMBDA (int i3, int i2, int i1) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(d3,d2,d1) , YAKL_LAMBDA (int i3, int i2, int i1) {
     array_out(i3,i1,i2) = array_in(i1,i2,i3);
-  });
+  }));
 }
 #endif
 

--- a/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
@@ -57,9 +57,10 @@ inline void reorder_123x321_kernel(int d1, int d2, int d3, ArrayInT const &array
   //     for (int t1=1; t1<=ntiles1; t1++) {
   //       for (int it3=1; it3<=TILE_SIZE; it3++) {
   //         for (int it1=1; it1<=TILE_SIZE; it1++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<5>({d2,ntiles1,ntiles3,TILE_SIZE,TILE_SIZE}) , KOKKOS_LAMBDA (int i2, int t1, int t3, int it1, int it3) {
-    int i3 = t3*TILE_SIZE + it3;
-    int i1 = t1*TILE_SIZE + it1;
+  //TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<5>({d2,ntiles1,ntiles3,TILE_SIZE,TILE_SIZE}) , KOKKOS_LAMBDA (int i2, int t1, int t3, int it1, int it3) {
+  //int i3 = t3*TILE_SIZE + it3;
+  //int i1 = t1*TILE_SIZE + it1;
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({d1,d2,d3}) , KOKKOS_LAMBDA (int i1, int i2, int i3) {
     if (i3 < d3 && i1 < d1) {
       array_out(i3,i2,i1) = array_in(i1,i2,i3);
     }

--- a/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
@@ -48,22 +48,17 @@ inline void reorder_123x321_kernel(int d1, int d2, int d3, ArrayInT const &array
   using DeviceT = typename ArrayInT::device_type;
   using LayoutT = typename ArrayInT::array_layout;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
-  int constexpr TILE_SIZE = 8;
-  int ntiles1 = (d1-1) / TILE_SIZE + 1;
-  int ntiles3 = (d3-1) / TILE_SIZE + 1;
+  // int constexpr TILE_SIZE = 8;
+  // int ntiles1 = (d1-1) / TILE_SIZE + 1;
+  // int ntiles3 = (d3-1) / TILE_SIZE + 1;
 
   // for (int i2=1; i2<=d2; i2++) {
   //   for (int t3=1; t3<=ntiles3; t3++) {
   //     for (int t1=1; t1<=ntiles1; t1++) {
   //       for (int it3=1; it3<=TILE_SIZE; it3++) {
   //         for (int it1=1; it1<=TILE_SIZE; it1++) {
-  //TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<5>({d2,ntiles1,ntiles3,TILE_SIZE,TILE_SIZE}) , KOKKOS_LAMBDA (int i2, int t1, int t3, int it1, int it3) {
-  //int i3 = t3*TILE_SIZE + it3;
-  //int i1 = t1*TILE_SIZE + it1;
   TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({d1,d2,d3}) , KOKKOS_LAMBDA (int i1, int i2, int i3) {
-    if (i3 < d3 && i1 < d1) {
-      array_out(i3,i2,i1) = array_in(i1,i2,i3);
-    }
+    array_out(i3,i2,i1) = array_in(i1,i2,i3);
   }));
 }
 

--- a/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
@@ -57,7 +57,7 @@ inline void reorder_123x321_kernel(int d1, int d2, int d3, ArrayInT const &array
   //     for (int t1=1; t1<=ntiles1; t1++) {
   //       for (int it3=1; it3<=TILE_SIZE; it3++) {
   //         for (int it1=1; it1<=TILE_SIZE; it1++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({d1,d2,d3}) , KOKKOS_LAMBDA (int i1, int i2, int i3) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getlr<3>({d1,d2,d3}) , KOKKOS_LAMBDA (int i1, int i2, int i3) {
     array_out(i3,i2,i1) = array_in(i1,i2,i3);
   }));
 }

--- a/cpp/rrtmgp/mo_gas_concentrations.h
+++ b/cpp/rrtmgp/mo_gas_concentrations.h
@@ -295,17 +295,17 @@ public:
     }
     if (w < 0. || w > 1.) { stoprun("GasConcs::set_vmr(): concentrations should be >= 0, <= 1"); }
     auto this_concs = this->concs;
-    Kokkos::parallel_for(mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA(int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA(int ilay, int icol) {
       this_concs(icol, ilay, igas) = w;
-    });
+    }));
   }
 
   template <typename ViewT>
   static void inline set_concs_impl(ViewT const &w, const int nlay, const int ncol, const int igas, const real3d_t& concs)
   {
-    Kokkos::parallel_for(mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA(int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA(int ilay, int icol) {
       concs(icol, ilay, igas) = w(ilay);
-    });
+    }));
   }
 
   // Set concentration as a single column copied to all other columns
@@ -332,9 +332,9 @@ public:
   template <typename ViewT>
   static void inline set_concs_impl2(ViewT const &w, const int nlay, const int ncol, const int igas, const real3d_t& concs)
   {
-    Kokkos::parallel_for(mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA(int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA(int ilay, int icol) {
       concs(icol, ilay, igas) = w(icol, ilay);
-    });
+    }));
   }
 
   // Set concentration as a 2-D field of columns and levels
@@ -371,9 +371,9 @@ public:
     // for (int ilay=1; ilay<=size(array,2); ilay++) {
     //   for (int icol=1; icol<=size(array,1); icol++) {
     auto this_concs = this->concs;
-    Kokkos::parallel_for( mdrp_t::template get<2>({array.extent(1),array.extent(0)}) , KOKKOS_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({array.extent(1),array.extent(0)}) , KOKKOS_LAMBDA (int ilay, int icol) {
       array(icol,ilay) = this_concs(icol,ilay,igas);
-    });
+    }));
   }
 
   int get_num_gases() const { return gas_name.size(); }

--- a/cpp/rrtmgp/mo_gas_concentrations.h
+++ b/cpp/rrtmgp/mo_gas_concentrations.h
@@ -102,9 +102,9 @@ public:
     YAKL_SCOPE( this_concs , this->concs );
     // for (int ilay=1; ilay<=this->nlay; ilay++) {
     //   for (int icol=1; icol<=this->ncol; icol++) {
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
       this_concs(icol,ilay,igas) = w;
-    });
+    }));
   }
 
 
@@ -124,17 +124,17 @@ public:
     #ifdef RRTMGP_EXPENSIVE_CHECKS
       yakl::ScalarLiveOut<bool> badVal(false); // Scalar that must exist in device memory (equiv: bool badVal = false;)
       // for (int i=1; i<=size(w,1); i++) {
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(size(w,1)) , YAKL_LAMBDA (int i) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(size(w,1)) , YAKL_LAMBDA (int i) {
         if (w(i) < 0. || w(i) > 1.) { badVal = true; }
-      });
+      }));
       if (badVal.hostRead()) { stoprun("GasConcs::set_vmr(): concentrations should be >= 0, <= 1"); }
     #endif
     YAKL_SCOPE( this_concs , this->concs );
     // for (int ilay=1; ilay<=this->nlay; ilay++) {
     //   for (int icol=1; icol<=this->ncol; icol++) {
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
       this_concs(icol,ilay,igas) = w(ilay);
-    });
+    }));
   }
 
   // Set concentration as a 2-D field of columns and levels
@@ -155,17 +155,17 @@ public:
       yakl::ScalarLiveOut<bool> badVal(false); // Scalar that must exist in device memory (equiv: bool badVal = false;)
       // for (int j=1; j<=size(w,2); j++) {
       //   for (int i=1; i<=size(w,1); i++) {
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(size(w,2),size(w,1)) , YAKL_LAMBDA (int j, int i) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(size(w,2),size(w,1)) , YAKL_LAMBDA (int j, int i) {
         if (w(i,j) < 0. || w(i,j) > 1.) { badVal = true;}
-      });
+      }));
       if (badVal.hostRead()) { stoprun("GasConcs::set_vmr(): concentrations should be >= 0, <= 1"); }
     #endif
     YAKL_SCOPE( this_concs , this->concs );
     // for (int ilay=1; ilay<=this->nlay; ilay++) {
     //   for (int icol=1; icol<=this->ncol; icol++) {
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
       this_concs(icol,ilay,igas) = w(icol,ilay);
-    });
+    }));
   }
 
 
@@ -183,9 +183,9 @@ public:
     // for (int ilay=1; ilay<=size(array,2); ilay++) {
     //   for (int icol=1; icol<=size(array,1); icol++) {
     YAKL_SCOPE( this_concs , this->concs );
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(size(array,2),size(array,1)) , YAKL_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(size(array,2),size(array,1)) , YAKL_LAMBDA (int ilay, int icol) {
       array(icol,ilay) = this_concs(icol,ilay,igas);
-    });
+    }));
   }
 
   int get_num_gases() const { return gas_name.size(); }
@@ -352,9 +352,9 @@ public:
       yakl::ScalarLiveOut<bool> badVal(false); // Scalar that must exist in device memory (equiv: bool badVal = false;)
       // for (int j=1; j<=size(w,2); j++) {
       //   for (int i=1; i<=size(w,1); i++) {
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(size(w,2),size(w,1)) , YAKL_LAMBDA (int j, int i) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(size(w,2),size(w,1)) , YAKL_LAMBDA (int j, int i) {
         if (w(i,j) < 0. || w(i,j) > 1.) { badVal = true;}
-      });
+      }));
       if (badVal.hostRead()) { stoprun("GasConcs::set_vmr(): concentrations should be >= 0, <= 1"); }
     #endif
     set_concs_impl2(w, this->nlay, this->ncol, igas, this->concs);

--- a/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
+++ b/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
@@ -561,9 +561,9 @@ public:
     YAKL_SCOPE( press_ref_loc     , this->press_ref     );
     YAKL_SCOPE( press_ref_log_loc , this->press_ref_log );
     // Running a kernel because it's more convenient in this case
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>( size(this->press_ref,1) ) , YAKL_LAMBDA (int i) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>( size(this->press_ref,1) ) , YAKL_LAMBDA (int i) {
       press_ref_log_loc(i) = log(press_ref_loc(i));
-    });
+    }));
 
     // log scale of reference pressure (this is a scalar, not an array)
     this->press_ref_trop_log = log(press_ref_trop);
@@ -614,14 +614,14 @@ public:
     this->is_key = bool1d("is_key",this->get_ngas());
     YAKL_SCOPE( is_key_loc , this->is_key );
     YAKL_SCOPE( flavor_loc , this->flavor );
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>( this->get_ngas() ) , YAKL_LAMBDA (int i) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>( this->get_ngas() ) , YAKL_LAMBDA (int i) {
       is_key_loc(i) = false;
-    });
+    }));
     // do j = 1, size(this%flavor, 2)
     //   do i = 1, size(this%flavor, 1) ! extents should be 2
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>( size(this->flavor,2) , size(this->flavor,1) ) , YAKL_LAMBDA (int j, int i) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>( size(this->flavor,2) , size(this->flavor,1) ) , YAKL_LAMBDA (int j, int i) {
       if (flavor_loc(i,j) != 0) { is_key_loc(flavor_loc(i,j)) = true; }
-    });
+    }));
   }
 
 
@@ -909,9 +909,9 @@ public:
     if (size(toa_src,1) != ncol || size(toa_src,2) != ngpt) { stoprun("gas_optics(): array toa_src has wrong size"); }
 
     YAKL_SCOPE( solar_src_loc , this->solar_src );
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       toa_src(icol,igpt) = solar_src_loc(igpt);
-    });
+    }));
   }
 
 
@@ -1005,15 +1005,15 @@ public:
     // compute column gas amounts [molec/cm^2]
     // do ilay = 1, nlay
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay,ncol) , YAKL_LAMBDA (int ilay, int icol) {
       col_gas(icol,ilay,0) = col_dry_wk(icol,ilay);
-    });
+    }));
     // do igas = 1, ngas
     //   do ilay = 1, nlay
     //     do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngas,nlay,ncol) , YAKL_LAMBDA (int igas, int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngas,nlay,ncol) , YAKL_LAMBDA (int igas, int ilay, int icol) {
       col_gas(icol,ilay,igas) = vmr(icol,ilay,igas) * col_dry_wk(icol,ilay);
-    });
+    }));
     // ---- calculate gas optical depths ----
     tau = 0;
 
@@ -1068,7 +1068,7 @@ public:
       //   Interpolation and extrapolation at boundaries is weighted by pressure
       // do ilay = 1, nlay+1
       //   do icol = 1, ncol
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay+1,ncol) , YAKL_LAMBDA (int ilay, int icol) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlay+1,ncol) , YAKL_LAMBDA (int ilay, int icol) {
         if (ilay == 1) {
           tlev_wk(icol,1) = tlay(icol,1) + (plev(icol,1)-play(icol,1))*(tlay(icol,2)-tlay(icol,1)) / (play(icol,2)-play(icol,1));
         }
@@ -1081,7 +1081,7 @@ public:
                                  play(icol,ilay  )*tlay(icol,ilay  )*(play(icol,ilay-1)-plev(icol,ilay)) ) /
                              (plev(icol,ilay)*(play(icol,ilay-1) - play(icol,ilay)));
         }
-      });
+      }));
     }
     // Compute internal (Planck) source functions at layers and levels,
     //  which depend on mapping from spectral space that creates k-distribution.
@@ -1095,9 +1095,9 @@ public:
     auto &sources_sfc_source = sources.sfc_source;
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       sources_sfc_source(icol,igpt) = sfc_source_t(igpt,icol);
-    });
+    }));
     reorder123x321(ngpt, nlay, ncol, lay_source_t    , sources.lay_source    );
     reorder123x321(ngpt, nlay, ncol, lev_source_inc_t, sources.lev_source_inc);
     reorder123x321(ngpt, nlay, ncol, lev_source_dec_t, sources.lev_source_dec);
@@ -1122,15 +1122,15 @@ public:
     if (allocated(latitude)) {
       // A purely OpenACC implementation would probably compute g0 within the kernel below
       // do icol = 1, ncol
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(ncol) , YAKL_LAMBDA (int icol) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(ncol) , YAKL_LAMBDA (int icol) {
         g0(icol) = helmert1 - helmert2 * cos(2.0 * M_PI * latitude(icol) / 180.0); // acceleration due to gravity [m/s^2]
-      });
+      }));
     } else {
       // do icol = 1, ncol
       YAKL_SCOPE( grav , const_t::grav );
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(ncol) , YAKL_LAMBDA (int icol) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(ncol) , YAKL_LAMBDA (int icol) {
         g0(icol) = grav;
-      });
+      }));
     }
 
     real2d col_dry("col_dry",size(plev,1),size(plev,2)-1);
@@ -1139,13 +1139,13 @@ public:
     YAKL_SCOPE( m_dry , const_t::m_dry );
     YAKL_SCOPE( m_h2o , const_t::m_h2o );
     YAKL_SCOPE( avogad , const_t::avogad );
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev-1,ncol) , YAKL_LAMBDA (int ilev , int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev-1,ncol) , YAKL_LAMBDA (int ilev , int icol) {
       real delta_plev = std::abs(plev(icol,ilev) - plev(icol,ilev+1));
       // Get average mass of moist air per mole of moist air
       real fact = 1. / (1.+vmr_h2o(icol,ilev));
       real m_air = (m_dry + m_h2o * vmr_h2o(icol,ilev)) * fact;
       col_dry(icol,ilev) = 10. * delta_plev * avogad * fact/(1000.*m_air*100.*g0(icol));
-    });
+    }));
     return col_dry;
   }
 

--- a/cpp/rrtmgp_const.h
+++ b/cpp/rrtmgp_const.h
@@ -30,13 +30,6 @@ using FOView = Kokkos::Experimental::OffsetView<T, Kokkos::LayoutLeft, Device>;
 
 template <typename T, typename Device=DefaultDevice>
 using COView = Kokkos::Experimental::OffsetView<T, Kokkos::LayoutRight, Device>;
-
-template <int Rank, typename ExecutionSpace=Kokkos::DefaultExecutionSpace>
-#ifdef KOKKOS_ENABLE_CUDA
-using MDRangeP = Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<Rank, Kokkos::Iterate::Left, Kokkos::Iterate::Right> >;
-#else
-using MDRangeP = Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<Rank> >;
-#endif
 #endif
 
 typedef double real;

--- a/cpp/rrtmgp_const.h
+++ b/cpp/rrtmgp_const.h
@@ -18,18 +18,6 @@ using DefaultDevice =
   Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>;
 using HostDevice =
   Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::DefaultHostExecutionSpace::memory_space>;
-
-template <typename T, typename Device=DefaultDevice>
-using FView = Kokkos::View<T, Kokkos::LayoutLeft, Device>;
-
-template <typename T, typename Device=DefaultDevice>
-using CView = Kokkos::View<T, Kokkos::LayoutRight, Device>;
-
-template <typename T, typename Device=DefaultDevice>
-using FOView = Kokkos::Experimental::OffsetView<T, Kokkos::LayoutLeft, Device>;
-
-template <typename T, typename Device=DefaultDevice>
-using COView = Kokkos::Experimental::OffsetView<T, Kokkos::LayoutRight, Device>;
 #endif
 
 typedef double real;

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -356,6 +356,12 @@ struct MDRP
   template <int Rank>
   using MDRP_t = Kokkos::MDRangePolicy<exe_space_t, Kokkos::Rank<Rank, LeftI, RightI> >;
 
+  template <int Rank>
+  using MDRPLR_t = Kokkos::MDRangePolicy<exe_space_t, Kokkos::Rank<Rank, Kokkos::Iterate::Left, Kokkos::Iterate::Right> >;
+
+  template <int Rank>
+  using MDRPRL_t = Kokkos::MDRangePolicy<exe_space_t, Kokkos::Rank<Rank, Kokkos::Iterate::Right, Kokkos::Iterate::Left> >;
+
   template <int N, typename IntT>
   static inline
   MDRP_t<N> get(const IntT (&upper_bounds)[N])
@@ -363,6 +369,25 @@ struct MDRP
     assert(N > 1);
     const IntT lower_bounds[N] = {0};
     return MDRP_t<N>(lower_bounds, upper_bounds); //, DefaultTile<N>::value);
+  }
+
+  template <int N, typename IntT>
+  static inline
+  MDRPLR_t<N> getlr(const IntT (&upper_bounds)[N])
+  {
+    assert(N > 1);
+    const IntT lower_bounds[N] = {0};
+    return MDRPLR_t<N>(lower_bounds, upper_bounds); //, DefaultTile<N>::value);
+  }
+
+
+  template <int N, typename IntT>
+  static inline
+  MDRPRL_t<N> getrl(const IntT (&upper_bounds)[N])
+  {
+    assert(N > 1);
+    const IntT lower_bounds[N] = {0};
+    return MDRPRL_t<N>(lower_bounds, upper_bounds); //, DefaultTile<N>::value);
   }
 
   template <int N, typename IntT>
@@ -375,24 +400,35 @@ struct MDRP
 };
 
 KOKKOS_INLINE_FUNCTION
-void unflatten_idx(const int idx, const Kokkos::Array<int, 2>& dims, int& i, int& j)
+void unflatten_idx_left(const int idx, const Kokkos::Array<int, 2>& dims, int& i, int& j)
 {
-  // i = idx / dims[1];
-  // j = idx % dims[1];
   i = idx % dims[0];
   j = idx / dims[0];
 }
 
 KOKKOS_INLINE_FUNCTION
-void unflatten_idx(const int idx, const Kokkos::Array<int, 3>& dims, int& i, int& j, int& k)
+void unflatten_idx_left(const int idx, const Kokkos::Array<int, 3>& dims, int& i, int& j, int& k)
 {
-  // i = (idx / dims[2]) / dims[1];
-  // j = (idx / dims[2]) % dims[1];
-  // k =  idx % dims[2];
   i = idx % dims[0];
   j = (idx / dims[0]) % dims[1];
   k = (idx / dims[0]) / dims[1];
 }
+
+KOKKOS_INLINE_FUNCTION
+void unflatten_idx_right(const int idx, const Kokkos::Array<int, 2>& dims, int& i, int& j)
+{
+  i = idx / dims[1];
+  j = idx % dims[1];
+}
+
+KOKKOS_INLINE_FUNCTION
+void unflatten_idx_right(const int idx, const Kokkos::Array<int, 3>& dims, int& i, int& j, int& k)
+{
+  i = (idx / dims[2]) / dims[1];
+  j = (idx / dims[2]) % dims[1];
+  k =  idx % dims[2];
+}
+
 
 #ifdef RRTMGP_ENABLE_YAKL
 // Compare a yakl array to a kokkos view, checking they are functionally

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -3,6 +3,7 @@
 #include "rrtmgp_const.h"
 
 #include <stdexcept>
+#include <chrono>
 
 // Validate if both enabled?
 #ifdef RRTMGP_ENABLE_KOKKOS
@@ -22,6 +23,23 @@
 #define GENERIC_INLINE KOKKOS_INLINE_FUNCTION
 #else
 #define GENERIC_INLINE YAKL_INLINE
+#endif
+
+//#define ENABLE_TIMING
+// Macro for timing kernels
+#ifdef ENABLE_TIMING
+#define TIMED_KERNEL(kernel)                                            \
+{                                                                       \
+  auto start_t = std::chrono::high_resolution_clock::now();             \
+  kernel;                                                               \
+  auto stop_t = std::chrono::high_resolution_clock::now();              \
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t); \
+  static double total_s = 0.;                                           \
+  total_s += duration.count() / 1000000.0;                              \
+  std::cout << "For file " << __FILE__ << ", line " << __LINE__ << ", total is: " << total_s << " s" << std::endl; \
+}
+#else
+#define TIMED_KERNEL(kernel) kernel
 #endif
 
 /**

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -4,7 +4,6 @@
 
 #include <stdexcept>
 #include <chrono>
-#include <source_location>
 
 // Validate if both enabled?
 #ifdef RRTMGP_ENABLE_KOKKOS
@@ -31,14 +30,13 @@
 #ifdef ENABLE_TIMING
 #define TIMED_KERNEL(kernel)                                            \
 {                                                                       \
-  const auto loc = std::source_location::current();                     \
   auto start_t = std::chrono::high_resolution_clock::now();             \
   kernel;                                                               \
   auto stop_t = std::chrono::high_resolution_clock::now();              \
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t); \
   static double total_s = 0.;                                           \
   total_s += duration.count() / 1000000.0;                              \
-  std::cout << "TIMING For func " << loc.function_name() << " file " << loc.file_name() << " line " << loc.line() << " total " << total_s << " s" << std::endl; \
+  std::cout << "TIMING For func " << __func__ << " file " << __FILE__ << " line " << __LINE__ << " total " << total_s << " s" << std::endl; \
 }
 #else
 #define TIMED_KERNEL(kernel) kernel

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -1306,7 +1306,9 @@ public:
         for (size_t i=0; i < arr.size(); ++i) { read_data.data()[i] -= 1; }
       }
     }
-    Kokkos::deep_copy(arr, read_data);
+    auto arr_mirror = Kokkos::create_mirror_view(arr);
+    Kokkos::deep_copy(arr_mirror, read_data);
+    Kokkos::deep_copy(arr, arr_mirror);
   }
 
 

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -356,6 +356,26 @@ struct MDRP
   }
 };
 
+KOKKOS_INLINE_FUNCTION
+void unflatten_idx(const int idx, const Kokkos::Array<int, 2>& dims, int& i, int& j)
+{
+  // i = idx / dims[1];
+  // j = idx % dims[1];
+  i = idx % dims[0];
+  j = idx / dims[0];
+}
+
+KOKKOS_INLINE_FUNCTION
+void unflatten_idx(const int idx, const Kokkos::Array<int, 3>& dims, int& i, int& j, int& k)
+{
+  // i = (idx / dims[2]) / dims[1];
+  // j = (idx / dims[2]) % dims[1];
+  // k =  idx % dims[2];
+  i = idx % dims[0];
+  j = (idx / dims[0]) % dims[1];
+  k = (idx / dims[0]) / dims[1];
+}
+
 #ifdef RRTMGP_ENABLE_YAKL
 // Compare a yakl array to a kokkos view, checking they are functionally
 // identical (same rank, dims, and values).

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -4,6 +4,7 @@
 
 #include <stdexcept>
 #include <chrono>
+#include <source_location>
 
 // Validate if both enabled?
 #ifdef RRTMGP_ENABLE_KOKKOS
@@ -25,18 +26,19 @@
 #define GENERIC_INLINE YAKL_INLINE
 #endif
 
-//#define ENABLE_TIMING
+#define ENABLE_TIMING
 // Macro for timing kernels
 #ifdef ENABLE_TIMING
 #define TIMED_KERNEL(kernel)                                            \
 {                                                                       \
+  const auto loc = std::source_location::current();                     \
   auto start_t = std::chrono::high_resolution_clock::now();             \
   kernel;                                                               \
   auto stop_t = std::chrono::high_resolution_clock::now();              \
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t); \
   static double total_s = 0.;                                           \
   total_s += duration.count() / 1000000.0;                              \
-  std::cout << "TIMING For file " << __FILE__ << ", line " << __LINE__ << ", total is: " << total_s << " s" << std::endl; \
+  std::cout << "TIMING For func " << loc.function_name() << " file " << loc.file_name() << " line " << loc.line() << " total " << total_s << " s" << std::endl; \
 }
 #else
 #define TIMED_KERNEL(kernel) kernel

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -319,12 +319,19 @@ template <> struct DefaultTile<5> {
 template <typename LayoutT, typename DeviceT=DefaultDevice>
 struct MDRP
 {
-  static constexpr Kokkos::Iterate LeftI = std::is_same_v<LayoutT, Kokkos::LayoutRight>
-    ? Kokkos::Iterate::Left
-    : Kokkos::Iterate::Right;
-  static constexpr Kokkos::Iterate RightI = std::is_same_v<LayoutT, Kokkos::LayoutRight>
-    ? Kokkos::Iterate::Right
-    : Kokkos::Iterate::Left;
+  // static constexpr Kokkos::Iterate LeftI = std::is_same_v<LayoutT, Kokkos::LayoutRight>
+  //   ? Kokkos::Iterate::Left
+  //   : Kokkos::Iterate::Right;
+  // static constexpr Kokkos::Iterate RightI = std::is_same_v<LayoutT, Kokkos::LayoutRight>
+  //   ? Kokkos::Iterate::Right
+  //   : Kokkos::Iterate::Left;
+#ifdef KOKKOS_ENABLE_CUDA
+  static constexpr Kokkos::Iterate LeftI = Kokkos::Iterate::Left;
+  static constexpr Kokkos::Iterate RightI = Kokkos::Iterate::Right;
+#else
+  static constexpr Kokkos::Iterate LeftI = Kokkos::Iterate::Default;
+  static constexpr Kokkos::Iterate RightI = Kokkos::Iterate::Default;
+#endif
 
   using exe_space_t = typename DeviceT::execution_space;
 

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -25,7 +25,7 @@
 #define GENERIC_INLINE YAKL_INLINE
 #endif
 
-#define ENABLE_TIMING
+//#define ENABLE_TIMING
 // Macro for timing kernels
 #ifdef ENABLE_TIMING
 #define TIMED_KERNEL(kernel)                                            \

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -36,7 +36,7 @@
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t); \
   static double total_s = 0.;                                           \
   total_s += duration.count() / 1000000.0;                              \
-  std::cout << "For file " << __FILE__ << ", line " << __LINE__ << ", total is: " << total_s << " s" << std::endl; \
+  std::cout << "TIMING For file " << __FILE__ << ", line " << __LINE__ << ", total is: " << total_s << " s" << std::endl; \
 }
 #else
 #define TIMED_KERNEL(kernel) kernel

--- a/cpp/rte/expand_and_transpose.cpp
+++ b/cpp/rte/expand_and_transpose.cpp
@@ -14,10 +14,10 @@ void expand_and_transpose(OpticalProps const &ops, real2d const &arr_in, real2d 
   int2d limits = ops.get_band_lims_gpoint();
   // for (int iband=1; iband <= nband; iband++) {
   //   for (int icol=1; icol <= ncol; icol++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nband,ncol) , YAKL_LAMBDA (int iband, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nband,ncol) , YAKL_LAMBDA (int iband, int icol) {
     for (int igpt=limits(1,iband); igpt <= limits(2,iband); igpt++) {
       arr_out(icol, igpt) = arr_in(iband,icol);
     }
-  });
+  }));
 }
 #endif

--- a/cpp/rte/expand_and_transpose.h
+++ b/cpp/rte/expand_and_transpose.h
@@ -24,10 +24,10 @@ void expand_and_transpose(OpticalPropsK<RealT, LayoutT, DeviceT> const &ops,
   Kokkos::View<int**, LayoutT, DeviceT> limits = ops.get_band_lims_gpoint();
   // for (int iband=1; iband <= nband; iband++) {
   //   for (int icol=1; icol <= ncol; icol++) {
-  Kokkos::parallel_for( mdrp_t::template get<2>({nband,ncol}) , KOKKOS_LAMBDA (int iband, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nband,ncol}) , KOKKOS_LAMBDA (int iband, int icol) {
     for (int igpt=limits(0,iband); igpt <= limits(1,iband); igpt++) {
       arr_out(icol, igpt) = arr_in(iband,icol);
     }
-  });
+  }));
 }
 #endif

--- a/cpp/rte/kernels/mo_fluxes_broadband_kernels.cpp
+++ b/cpp/rte/kernels/mo_fluxes_broadband_kernels.cpp
@@ -33,13 +33,13 @@ void sum_broadband(int ncol, int nlev, int ngpt, real3d const &spectral_flux, re
   #else
     // do ilev = 1, nlev
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev,ncol) , YAKL_LAMBDA (int ilev, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev,ncol) , YAKL_LAMBDA (int ilev, int icol) {
       real bb_flux_s = 0.0;
       for (int igpt=1; igpt<=ngpt; igpt++) {
         bb_flux_s += spectral_flux(icol, ilev, igpt);
       }
       broadband_flux(icol, ilev) = bb_flux_s;
-    });
+    }));
   #endif
 }
 
@@ -51,20 +51,20 @@ void net_broadband(int ncol, int nlev, int ngpt, real3d const &spectral_flux_dn,
 
   // do ilev = 1, nlev
   //   do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev,ncol) , YAKL_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev,ncol) , YAKL_LAMBDA (int ilev, int icol) {
     real diff = spectral_flux_dn(icol, ilev, 1) - spectral_flux_up(icol, ilev, 1);
     broadband_flux_net(icol, ilev) = diff;
-  });
+  }));
 
   // do igpt = 2, ngpt
   //   do ilev = 1, nlev
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , Bounds<2>(nlev,ncol) , YAKL_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<2>(nlev,ncol) , YAKL_LAMBDA (int ilev, int icol) {
     for (int igpt=2; igpt<=ngpt; igpt++) {
       real diff = spectral_flux_dn(icol, ilev, igpt) - spectral_flux_up(icol, ilev, igpt);
       broadband_flux_net(icol,ilev) += diff;
     }
-  });
+  }));
 #ifdef RRTMGP_DEBUG
   std::cout << "WARNING: THIS ISN'T TESTED!\n";
   std::cout << __FILE__ << ": " << __LINE__ << std::endl;
@@ -78,8 +78,8 @@ void net_broadband(int ncol, int nlev, real2d const &flux_dn, real2d const &flux
 
   // do ilev = 1, nlev
   //   do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev,ncol) , YAKL_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(nlev,ncol) , YAKL_LAMBDA (int ilev, int icol) {
      broadband_flux_net(icol,ilev) = flux_dn(icol,ilev) - flux_up(icol,ilev);
-  });
+  }));
 }
 #endif

--- a/cpp/rte/kernels/mo_fluxes_broadband_kernels.h
+++ b/cpp/rte/kernels/mo_fluxes_broadband_kernels.h
@@ -25,13 +25,13 @@ void sum_broadband(int ncol, int nlev, int ngpt, SpectralT const &spectral_flux,
 
   // do ilev = 1, nlev
   //   do icol = 1, ncol
-  Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
     RealT bb_flux_s = 0.0;
     for (int igpt=0; igpt<ngpt; igpt++) {
       bb_flux_s += spectral_flux(icol, ilev, igpt);
     }
     broadband_flux(icol, ilev) = bb_flux_s;
-  });
+  }));
 }
 
 // Net flux: Spectral reduction over all points
@@ -44,20 +44,20 @@ void net_broadband(int ncol, int nlev, int ngpt, SpectralDnT const &spectral_flu
 
   // do ilev = 1, nlev
   //   do icol = 1, ncol
-  Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
     RealT diff = spectral_flux_dn(icol, ilev, 0) - spectral_flux_up(icol, ilev, 0);
     broadband_flux_net(icol, ilev) = diff;
-  });
+  }));
 
   // do igpt = 2, ngpt
   //   do ilev = 1, nlev
   //     do icol = 1, ncol
-  Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
     for (int igpt=1; igpt<ngpt; igpt++) {
       RealT diff = spectral_flux_dn(icol, ilev, igpt) - spectral_flux_up(icol, ilev, igpt);
       broadband_flux_net(icol,ilev) += diff;
     }
-  });
+  }));
 #ifdef RRTMGP_DEBUG
   std::cout << "WARNING: THIS ISN'T TESTED!\n";
   std::cout << __FILE__ << ": " << __LINE__ << std::endl;
@@ -73,8 +73,8 @@ void net_broadband(int ncol, int nlev, FluxDnT const &flux_dn, FluxUpT const &fl
 
   // do ilev = 1, nlev
   //   do icol = 1, ncol
-  Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
      broadband_flux_net(icol,ilev) = flux_dn(icol,ilev) - flux_up(icol,ilev);
-  });
+  }));
 }
 #endif

--- a/cpp/rte/kernels/mo_optical_props_kernels.cpp
+++ b/cpp/rte/kernels/mo_optical_props_kernels.cpp
@@ -15,7 +15,7 @@ void inc_2stream_by_2stream_bybnd(int ncol, int nlay, int ngpt,
   // do igpt = 1 , ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<4>(nbnd,ngpt,nlay,ncol) , YAKL_LAMBDA (int ibnd, int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<4>(nbnd,ngpt,nlay,ncol) , YAKL_LAMBDA (int ibnd, int igpt, int ilay, int icol) {
     if (igpt >= gpt_lims(1,ibnd) && igpt <= gpt_lims(2,ibnd) ) {
       // t=tau1 + tau2
       real tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd);
@@ -27,7 +27,7 @@ void inc_2stream_by_2stream_bybnd(int ncol, int nlay, int ngpt,
       ssa1(icol,ilay,igpt) = tauscat12 / std::max(eps,tau12);
       tau1(icol,ilay,igpt) = tau12;
     }
-  });
+  }));
 }
 
 
@@ -63,13 +63,13 @@ void inc_1scalar_by_1scalar_bybnd(int ncol, int nlay, int ngpt, real3d const &ta
     // do igpt = 1 , ngpt
     //   do ilay = 1 , nlay
     //     do icol = 1 , ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
       for (int ibnd=1; ibnd<=nbnd; ibnd++) {
         if (igpt >= gpt_lims(1,ibnd) && igpt <= gpt_lims(2,ibnd) ) {
           tau1(icol,ilay,igpt) += tau2(icol,ilay,ibnd);
         }
       }
-    });
+    }));
   #endif
 }
 
@@ -86,7 +86,7 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, real3d const &tau, re
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     if (tau(icol,ilay,igpt) > eps) {
       real f  = g  (icol,ilay,igpt) * g  (icol,ilay,igpt);
       real wf = ssa(icol,ilay,igpt) * f;
@@ -94,7 +94,7 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, real3d const &tau, re
       ssa(icol,ilay,igpt) = (ssa(icol,ilay,igpt) - wf) / (1.0 - wf);
       g  (icol,ilay,igpt) = (g  (icol,ilay,igpt) -  f) / (1.0 -  f);
     }
-  });
+  }));
 }
 
 
@@ -111,14 +111,14 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, real3d const &tau, re
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     if (tau(icol,ilay,igpt) > eps) {
       real wf = ssa(icol,ilay,igpt) * f(icol,ilay,igpt);
       tau(icol,ilay,igpt) = (1. - wf) * tau(icol,ilay,igpt);
       ssa(icol,ilay,igpt) = (ssa(icol,ilay,igpt) - wf) /  (1.0 - wf);
       g  (icol,ilay,igpt) = (g  (icol,ilay,igpt) - f(icol,ilay,igpt)) / (1. - f(icol,ilay,igpt));
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -143,9 +143,9 @@ void increment_1scalar_by_1scalar(int ncol, int nlay, int ngpt, real3d const &ta
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
-  });
+  }));
   //std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -159,9 +159,9 @@ void increment_1scalar_by_2stream(int ncol, int nlay, int ngpt, real3d const &ta
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt) * (1. - ssa2(icol,ilay,igpt));
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -175,9 +175,9 @@ void increment_1scalar_by_nstream(int ncol, int nlay, int ngpt, real3d const &ta
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt) * (1. - ssa2(icol,ilay,igpt));
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -193,14 +193,14 @@ void increment_2stream_by_1scalar(int ncol, int nlay, int ngpt, real3d const &ta
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     real tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
     if (tau12 > eps) {
       ssa1(icol,ilay,igpt) = tau1(icol,ilay,igpt) * ssa1(icol,ilay,igpt) / tau12;
       tau1(icol,ilay,igpt) = tau12;
       // g is unchanged
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -217,7 +217,7 @@ void increment_2stream_by_2stream(int ncol, int nlay, int ngpt, real3d const &ta
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     // t=tau1 + tau2
     real tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
     // w=(tau1*ssa1 + tau2*ssa2) / t
@@ -228,7 +228,7 @@ void increment_2stream_by_2stream(int ncol, int nlay, int ngpt, real3d const &ta
                            / std::max(eps,tauscat12);
     ssa1(icol,ilay,igpt) = tauscat12 / std::max(eps,tau12);
     tau1(icol,ilay,igpt) = tau12;
-  });
+  }));
   //std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -244,7 +244,7 @@ void increment_2stream_by_nstream(int ncol, int nlay, int ngpt, int nmom2, real3
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     // t=tau1 + tau2
     real tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
     // w=(tau1*ssa1 + tau2*ssa2) / t
@@ -256,7 +256,7 @@ void increment_2stream_by_nstream(int ncol, int nlay, int ngpt, int nmom2, real3
       ssa1(icol,ilay,igpt) = tauscat12 / tau12;
       tau1(icol,ilay,igpt) = tau12;
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -272,14 +272,14 @@ void increment_nstream_by_1scalar(int ncol, int nlay, int ngpt, real3d const &ta
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     real tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
     if (tau12 > eps) {
       ssa1(icol,ilay,igpt) = tau1(icol,ilay,igpt) * ssa1(icol,ilay,igpt) / tau12;
       tau1(icol,ilay,igpt) = tau12;
       // p is unchanged
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -297,7 +297,7 @@ void increment_nstream_by_2stream(int ncol, int nlay, int ngpt, int nmom1, real3
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     real tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
     real tauscat12 = tau1(icol,ilay,igpt) * ssa1(icol,ilay,igpt) +
                      tau2(icol,ilay,igpt) * ssa2(icol,ilay,igpt);
@@ -314,7 +314,7 @@ void increment_nstream_by_2stream(int ncol, int nlay, int ngpt, int nmom1, real3
       ssa1(icol,ilay,igpt) = tauscat12 / tau12;
       tau1(icol,ilay,igpt) = tau12;
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -332,7 +332,7 @@ void increment_nstream_by_nstream(int ncol, int nlay, int ngpt, int nmom1, int n
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     real tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
     real tauscat12 = tau1(icol,ilay,igpt) * ssa1(icol,ilay,igpt) +
                      tau2(icol,ilay,igpt) * ssa2(icol,ilay,igpt);
@@ -346,7 +346,7 @@ void increment_nstream_by_nstream(int ncol, int nlay, int ngpt, int nmom1, int n
       ssa1(icol,ilay,igpt) = tauscat12 / std::max(eps,tau12);
       tau1(icol,ilay,igpt) = tau12;
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -361,13 +361,13 @@ void inc_1scalar_by_2stream_bybnd(int ncol, int nlay, int ngpt, real3d const &ta
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     for (int ibnd=1; ibnd<=nbnd; ibnd++) {
       if (igpt >= gpt_lims(1, ibnd) && igpt <= gpt_lims(2, ibnd) ) {
         tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd) * (1. - ssa2(icol,ilay,ibnd));
       }
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -382,13 +382,13 @@ void inc_1scalar_by_nstream_bybnd(int ncol, int nlay, int ngpt, real3d const &ta
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     for (int ibnd=1; ibnd<=nbnd; ibnd++) {
       if (igpt >= gpt_lims(1, ibnd) && igpt <= gpt_lims(2, ibnd) ) {
         tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd) * (1. - ssa2(icol,ilay,ibnd));
       }
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -405,7 +405,7 @@ void inc_2stream_by_1scalar_bybnd(int ncol, int nlay, int ngpt, real3d const &ta
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     for (int ibnd=1; ibnd<=nbnd; ibnd++) {
       if (igpt >= gpt_lims(1, ibnd) && igpt <= gpt_lims(2, ibnd) ) {
         real tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd);
@@ -414,7 +414,7 @@ void inc_2stream_by_1scalar_bybnd(int ncol, int nlay, int ngpt, real3d const &ta
         // g is unchanged
       }
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -431,7 +431,7 @@ void inc_2stream_by_nstream_bybnd(int ncol, int nlay, int ngpt, int nmom2, real3
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     for (int ibnd=1; ibnd<=nbnd; ibnd++) {
       if (igpt >= gpt_lims(1, ibnd) && igpt <= gpt_lims(2, ibnd) ) {
         // t=tau1 + tau2
@@ -445,7 +445,7 @@ void inc_2stream_by_nstream_bybnd(int ncol, int nlay, int ngpt, int nmom2, real3
         tau1(icol,ilay,igpt) = tau12;
       }
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -462,7 +462,7 @@ void inc_nstream_by_1scalar_bybnd(int ncol, int nlay, int ngpt, real3d const &ta
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     for (int ibnd=1; ibnd<=nbnd; ibnd++) {
       if (igpt >= gpt_lims(1, ibnd) && igpt <= gpt_lims(2, ibnd) ) {
         real tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd);
@@ -471,7 +471,7 @@ void inc_nstream_by_1scalar_bybnd(int ncol, int nlay, int ngpt, real3d const &ta
         // p is unchanged
       }
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -490,7 +490,7 @@ void inc_nstream_by_2stream_bybnd(int ncol, int nlay, int ngpt, int nmom1, real3
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     for (int ibnd=1; ibnd<=nbnd; ibnd++) {
       if (igpt >= gpt_lims(1, ibnd) && igpt <= gpt_lims(2, ibnd) ) {
         real tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd);
@@ -509,7 +509,7 @@ void inc_nstream_by_2stream_bybnd(int ncol, int nlay, int ngpt, int nmom1, real3
         tau1(icol,ilay,igpt) = tau12;
       }
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -527,7 +527,7 @@ void inc_nstream_by_nstream_bybnd(int ncol, int nlay, int ngpt, int nmom1, int n
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     for (int ibnd=0; ibnd<=nbnd; ibnd++) {
       if (igpt >= gpt_lims(1, ibnd) && igpt <= gpt_lims(2, ibnd) ) {
         real tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd);
@@ -543,7 +543,7 @@ void inc_nstream_by_nstream_bybnd(int ncol, int nlay, int ngpt, int nmom1, int n
         tau1(icol,ilay,igpt) = tau12;
       }
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -557,9 +557,9 @@ void extract_subset_dim1_3d(int ncol, int nlay, int ngpt, real3d const &array_in
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = colS, colE
-  parallel_for( YAKL_AUTO_LABEL() , Bounds<3>(ngpt,nlay,{colS,colE}) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<3>(ngpt,nlay,{colS,colE}) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     array_out(icol-colS+1, ilay, igpt) = array_in(icol, ilay, igpt);
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -573,9 +573,9 @@ void extract_subset_dim2_4d(int nmom, int ncol, int nlay, int ngpt, real4d const
   //  do ilay = 1, nlay
   //    do icol = colS, colE
   //      do imom = 1, nmom
-  parallel_for( YAKL_AUTO_LABEL() , Bounds<4>(ngpt,nlay,{colS,colE},nmom) , YAKL_LAMBDA (int igpt, int ilay, int icol, int imom) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<4>(ngpt,nlay,{colS,colE},nmom) , YAKL_LAMBDA (int igpt, int ilay, int icol, int imom) {
     array_out(imom, icol-colS+1, ilay, igpt) = array_in(imom, icol, ilay, igpt);
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -589,9 +589,9 @@ void extract_subset_absorption_tau(int ncol, int nlay, int ngpt, real3d const &t
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = colS, colE
-  parallel_for( YAKL_AUTO_LABEL() , Bounds<3>(ngpt,nlay,{colS,colE}) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<3>(ngpt,nlay,{colS,colE}) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     tau_out(icol-colS+1, ilay, igpt) = tau_in(icol, ilay, igpt) * (1. - ssa_in(icol, ilay, igpt));
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 #endif

--- a/cpp/rte/kernels/mo_optical_props_kernels.h
+++ b/cpp/rte/kernels/mo_optical_props_kernels.h
@@ -168,7 +168,7 @@ void inc_2stream_by_2stream_bybnd(int ncol, int nlay, int ngpt,
   // do igpt = 1 , ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  Kokkos::parallel_for( mdrp_t::template get<4>({nbnd,ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int ibnd, int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<4>({nbnd,ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int ibnd, int igpt, int ilay, int icol) {
     if (igpt >= gpt_lims(0,ibnd) && igpt <= gpt_lims(1,ibnd) ) {
       // t=tau1 + tau2
       RealT tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd);
@@ -180,7 +180,7 @@ void inc_2stream_by_2stream_bybnd(int ncol, int nlay, int ngpt,
       ssa1(icol,ilay,igpt) = tauscat12 / Kokkos::fmax(eps,tau12);
       tau1(icol,ilay,igpt) = tau12;
     }
-  });
+  }));
 }
 
 // Addition of optical properties: the first set are incremented by the second set.
@@ -204,9 +204,9 @@ void increment_1scalar_by_1scalar(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}), KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}), KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
     tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
-  });
+  }));
   //std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -222,13 +222,13 @@ void inc_1scalar_by_1scalar_bybnd(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1 , ngpt
   //   do ilay = 1 , nlay
   //     do icol = 1 , ncol
-  Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
     for (int ibnd=0; ibnd<nbnd; ibnd++) {
       if (igpt >= gpt_lims(0,ibnd) && igpt <= gpt_lims(1,ibnd) ) {
         tau1(icol,ilay,igpt) += tau2(icol,ilay,ibnd);
       }
     }
-  });
+  }));
 }
 
 // Delta-scale
@@ -245,7 +245,7 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, TauT const &tau, SsaT
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
     if (tau(icol,ilay,igpt) > eps) {
       RealT f  = g  (icol,ilay,igpt) * g  (icol,ilay,igpt);
       RealT wf = ssa(icol,ilay,igpt) * f;
@@ -253,7 +253,7 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, TauT const &tau, SsaT
       ssa(icol,ilay,igpt) = (ssa(icol,ilay,igpt) - wf) / (1.0 - wf);
       g  (icol,ilay,igpt) = (g  (icol,ilay,igpt) -  f) / (1.0 -  f);
     }
-  });
+  }));
 }
 
 
@@ -272,14 +272,14 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, TauT const &tau, SsaT
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
     if (tau(icol,ilay,igpt) > eps) {
       RealT wf = ssa(icol,ilay,igpt) * f(icol,ilay,igpt);
       tau(icol,ilay,igpt) = (1. - wf) * tau(icol,ilay,igpt);
       ssa(icol,ilay,igpt) = (ssa(icol,ilay,igpt) - wf) /  (1.0 - wf);
       g  (icol,ilay,igpt) = (g  (icol,ilay,igpt) - f(icol,ilay,igpt)) / (1. - f(icol,ilay,igpt));
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -297,7 +297,7 @@ void increment_2stream_by_2stream(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
     // t=tau1 + tau2
     RealT tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
     // w=(tau1*ssa1 + tau2*ssa2) / t
@@ -308,7 +308,7 @@ void increment_2stream_by_2stream(int ncol, int nlay, int ngpt, Tau1T const &tau
                            / Kokkos::fmax(eps,tauscat12);
     ssa1(icol,ilay,igpt) = tauscat12 / Kokkos::fmax(eps,tau12);
     tau1(icol,ilay,igpt) = tau12;
-  });
+  }));
   //std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 

--- a/cpp/rte/kernels/mo_rte_solver_kernels.cpp
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.cpp
@@ -11,15 +11,15 @@ void apply_BC(int ncol, int nlay, int ngpt, bool top_at_1, real3d const &flux_dn
   if (top_at_1) {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       flux_dn(icol,      1, igpt)  = 0;
-    });
+    }));
   } else {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       flux_dn(icol, nlay+1, igpt)  = 0;
-    });
+    }));
   }
 }
 
@@ -32,15 +32,15 @@ void apply_BC(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &inc_flu
   if (top_at_1) {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       flux_dn(icol,      1, igpt)  = inc_flux(icol,igpt) * factor(icol);
-    });
+    }));
   } else {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       flux_dn(icol, nlay+1, igpt)  = inc_flux(icol,igpt) * factor(icol);
-    });
+    }));
   }
 }
 
@@ -56,16 +56,16 @@ void apply_BC(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &inc_flu
     //$acc  parallel loop collapse(2)
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       flux_dn(icol,      1, igpt)  = inc_flux(icol,igpt);
-    });
+    }));
   } else {
     //$acc  parallel loop collapse(2)
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       flux_dn(icol, nlay+1, igpt)  = inc_flux(icol,igpt);
-    });
+    }));
   }
 }
 
@@ -89,7 +89,7 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &albedo_sf
   if (top_at_1) {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       int ilev = nlay + 1;
       // Albedo of lowest level is the surface albedo...
       albedo(icol,ilev,igpt)  = albedo_sfc(icol,igpt);
@@ -123,7 +123,7 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &albedo_sf
         flux_up(icol,ilev,igpt) = flux_dn(icol,ilev,igpt) * albedo(icol,ilev,igpt) +  // Equation 12
                                   src(icol,ilev,igpt);
       }
-    });
+    }));
 
   } else {
 
@@ -185,7 +185,7 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &albedo_sf
     #else
       // do igpt = 1, ngpt
       //   do icol = 1, ncol
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
         int ilev = 1;
         // Albedo of lowest level is the surface albedo...
         albedo(icol,ilev,igpt)  = albedo_sfc(icol,igpt);
@@ -220,7 +220,7 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &albedo_sf
                                     src(icol,ilev,igpt);
 
         }
-      });
+      }));
     #endif
   }
 }
@@ -260,9 +260,9 @@ void sw_solver_2stream(int ncol, int nlay, int ngpt, bool top_at_1, real3d const
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay+1
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay+1,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay+1,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     flux_dn(icol,ilay,igpt) = flux_dn(icol,ilay,igpt) + flux_dir(icol,ilay,igpt);
-  });
+  }));
 }
 
 
@@ -310,7 +310,7 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, real2d const 
 
   // do igpt = 1, ngpt
   //   do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
     // Transport is for intensity
     //   convert flux at top of domain to intensity assuming azimuthal isotropy
     radn_dn(icol,top_level,igpt) = radn_dn(icol,top_level,igpt)/(2. * pi * weights(weight_ind));
@@ -318,14 +318,14 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, real2d const 
     // Surface albedo, surface source function
     sfc_albedo(icol,igpt) = 1. - sfc_emis(icol,igpt);
     source_sfc(icol,igpt) = sfc_emis(icol,igpt) * sfc_src(icol,igpt);
-  });
+  }));
 
   real3d source_dn ("source_dn ",ncol,nlay,ngpt);
   real3d source_up ("source_up ",ncol,nlay,ngpt);
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     // Optical path and transmission, used in source function and transport calculations
     tau_loc(icol,ilay,igpt) = tau(icol,ilay,igpt)*D(icol,igpt);
     trans  (icol,ilay,igpt) = exp(-tau_loc(icol,ilay,igpt));
@@ -334,7 +334,7 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, real2d const 
                              lay_source, lev_source_up, lev_source_dn,
                              tau_loc, trans,
                              source_dn, source_up, tau_thresh);
-  });
+  }));
 
   // Transport
   lw_transport_noscat(ncol, nlay, ngpt, top_at_1,
@@ -345,10 +345,10 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, real2d const 
   // do igpt = 1, ngpt
   //   do ilev = 1, nlay+1
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay+1,ncol) , YAKL_LAMBDA (int igpt, int ilev, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay+1,ncol) , YAKL_LAMBDA (int igpt, int ilev, int icol) {
     radn_dn(icol,ilev,igpt) = 2. * pi * weights(weight_ind) * radn_dn(icol,ilev,igpt);
     radn_up(icol,ilev,igpt) = 2. * pi * weights(weight_ind) * radn_up(icol,ilev,igpt);
-  });
+  }));
 }
 
 
@@ -371,9 +371,9 @@ void lw_solver_noscat_GaussQuad(int ncol, int nlay, int ngpt, bool top_at_1, int
 
   // do igpt = 1, ngpt
   //   do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
     Ds_ncol(icol, igpt) = Ds(1);
-  });
+  }));
 
   lw_solver_noscat(ncol, nlay, ngpt,
                    top_at_1, Ds_ncol, weights, 1, tau,
@@ -385,18 +385,18 @@ void lw_solver_noscat_GaussQuad(int ncol, int nlay, int ngpt, bool top_at_1, int
 
   // do igpt = 1, ngpt
   //   do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
     flux_top(icol,igpt) = flux_dn(icol,top_level,igpt);
-  });
+  }));
 
   apply_BC(ncol, nlay, ngpt, top_at_1, flux_top, radn_dn);
 
   for (int imu=2; imu<=nmus; imu++) {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       Ds_ncol(icol, igpt) = Ds(imu);
-    });
+    }));
 
     lw_solver_noscat(ncol, nlay, ngpt,
                      top_at_1, Ds_ncol, weights, imu, tau,
@@ -406,10 +406,10 @@ void lw_solver_noscat_GaussQuad(int ncol, int nlay, int ngpt, bool top_at_1, int
     // do igpt = 1, ngpt
     //   do ilev = 1, nlay+1
     //     do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay+1,ncol) , YAKL_LAMBDA (int igpt, int ilev, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay+1,ncol) , YAKL_LAMBDA (int igpt, int ilev, int icol) {
       flux_up(icol,ilev,ngpt) = flux_up(icol,ilev,ngpt) + radn_up(icol,ilev,ngpt);
       flux_dn(icol,ilev,ngpt) = flux_dn(icol,ilev,ngpt) + radn_dn(icol,ilev,ngpt);
-    });
+    }));
 
   } // imu
 }
@@ -431,7 +431,7 @@ void lw_source_2str(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &s
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     if ( tau(icol,ilay,ngpt) > 1.0e-8 ) {
       real lev_source_top, lev_source_bot;
       if (top_at_1) {
@@ -456,7 +456,7 @@ void lw_source_2str(int ncol, int nlay, int ngpt, bool top_at_1, real2d const &s
     if(ilay == 1) {
       source_sfc(icol,igpt) = pi * sfc_emis(icol,igpt) * sfc_src(icol,igpt);
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -474,7 +474,7 @@ void lw_combine_sources(int ncol, int nlay, int ngpt, bool top_at_1, real3d cons
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay+1
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay+1,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay+1,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     if (ilay == 1) {
       lev_source(icol, ilay, igpt) =      lev_src_dec(icol, ilay,   igpt);
     } else if (ilay == nlay+1) {
@@ -483,7 +483,7 @@ void lw_combine_sources(int ncol, int nlay, int ngpt, bool top_at_1, real3d cons
       lev_source(icol, ilay, igpt) = sqrt(lev_src_dec(icol, ilay, igpt) *
                                           lev_src_inc(icol, ilay-1, igpt));
     }
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -503,7 +503,7 @@ void lw_two_stream(int ncol, int nlay, int ngpt, real3d const &tau, real3d const
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     // Coefficients differ from SW implementation because the phase function is more isotropic
     //   Here we follow Fu et al. 1997, doi:10.1175/1520-0469(1997)054<2799:MSPITI>2.0.CO;2
     //   and use a diffusivity sec of 1.66
@@ -530,7 +530,7 @@ void lw_two_stream(int ncol, int nlay, int ngpt, real3d const &tau, real3d const
 
     // Equation 26
     Tdif(icol,ilay,igpt) = RT_term * 2. * k * exp_minusktau;
-  });
+  }));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -545,9 +545,9 @@ void sw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, real3d const 
 
   real1d mu0_inv("mu0_inv",ncol);
 
-  parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA (int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA (int icol) {
     mu0_inv(icol) = 1./mu0(icol);
-  });
+  }));
 
   // Indexing into arrays for upward and downward propagation depends on the vertical
   //   orientation of the arrays (whether the domain top is at the first or last index)
@@ -560,21 +560,21 @@ void sw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, real3d const 
     // previous level is up (-1)
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       for (int ilev=2; ilev<=nlay+1; ilev++) {
         flux_dir(icol,ilev,igpt) = flux_dir(icol,ilev-1,igpt) * exp(-tau(icol,ilev,igpt)*mu0_inv(icol));
       }
-    });
+    }));
   } else {
     // layer index = level index
     // previous level is up (+1)
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       for (int ilev=nlay; ilev>=1; ilev--) {
         flux_dir(icol,ilev,igpt) = flux_dir(icol,ilev+1,igpt) * exp(-tau(icol,ilev,igpt)*mu0_inv(icol));
       }
-    });
+    }));
   }
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
@@ -623,9 +623,9 @@ void lw_solver_2stream(int ncol, int nlay, int ngpt, bool top_at_1, real3d const
 
   // do igpt = 1, ngpt
   //   do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
     sfc_albedo(icol,igpt) = 1. - sfc_emis(icol,igpt);
-  });
+  }));
 
   // Transport
   adding(ncol, nlay, ngpt, top_at_1,

--- a/cpp/rte/kernels/mo_rte_solver_kernels.h
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.h
@@ -471,7 +471,11 @@ inline void lw_transport_noscat(int ncol, int nlay, int ngpt, bool top_at_1, Tau
     // Top of domain is index nlay+1
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    Kokkos::Array<int, 2> dims2_ncol_ngpt = {ncol,ngpt};
+    const int dims2_tot = ncol*ngpt;
+    TIMED_KERNEL(Kokkos::parallel_for( dims2_tot , KOKKOS_LAMBDA (int idx) {
+      int icol, igpt;
+      conv::unflatten_idx_left(idx, dims2_ncol_ngpt, icol, igpt);
       // Downward propagation
       for (int ilev=nlay-1; ilev>=0; ilev--) {
         radn_dn(icol,ilev,igpt) = trans(icol,ilev  ,igpt)*radn_dn(icol,ilev+1,igpt) + source_dn(icol,ilev,igpt);

--- a/cpp/rte/kernels/mo_rte_solver_kernels.h
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.h
@@ -723,7 +723,7 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, AlbedoSfcT const &albed
   } else {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<2>({ncol,ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       int ilev = 0;
       // Albedo of lowest level is the surface albedo...
       albedo(icol,ilev,igpt)  = albedo_sfc(icol,igpt);

--- a/cpp/rte/kernels/mo_rte_solver_kernels.h
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.h
@@ -45,7 +45,7 @@ inline void sw_source_2str(int ncol, int nlay, int ngpt, bool top_at_1, real3d c
   if (top_at_1) {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       for (int ilev=1; ilev<=nlay; ilev++) {
         source_up(icol,ilev,igpt)     =    Rdir(icol,ilev,igpt) * flux_dn_dir(icol,ilev,igpt);
         source_dn(icol,ilev,igpt)     =    Tdir(icol,ilev,igpt) * flux_dn_dir(icol,ilev,igpt);
@@ -54,7 +54,7 @@ inline void sw_source_2str(int ncol, int nlay, int ngpt, bool top_at_1, real3d c
           source_sfc(icol,igpt) = flux_dn_dir(icol,nlay+1,igpt)*sfc_albedo(icol,igpt);
         }
       }
-    });
+    }));
   } else {
     #ifdef RRTMGP_CPU_KERNELS
       #ifdef YAKL_AUTO_PROFILE
@@ -84,7 +84,7 @@ inline void sw_source_2str(int ncol, int nlay, int ngpt, bool top_at_1, real3d c
       // previous level is up (+1)
       // do igpt = 1, ngpt
       //   do icol = 1, ncol
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
         for (int ilev=nlay; ilev>=1; ilev--) {
           source_up(icol,ilev,igpt)   =    Rdir(icol,ilev,igpt) * flux_dn_dir(icol,ilev+1,igpt);
           source_dn(icol,ilev,igpt)   =    Tdir(icol,ilev,igpt) * flux_dn_dir(icol,ilev+1,igpt);
@@ -93,7 +93,7 @@ inline void sw_source_2str(int ncol, int nlay, int ngpt, bool top_at_1, real3d c
             source_sfc(icol,igpt) = flux_dn_dir(icol,    1,igpt)*sfc_albedo(icol,igpt);
           }
         }
-      });
+      }));
     #endif
   }
 }
@@ -111,7 +111,7 @@ inline void lw_transport_noscat(int ncol, int nlay, int ngpt, bool top_at_1, rea
     // Top of domain is index 1
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
       // Downward propagation
       for (int ilev=2; ilev<=nlay+1; ilev++) {
         radn_dn(icol,ilev,igpt) = trans(icol,ilev-1,igpt)*radn_dn(icol,ilev-1,igpt) + source_dn(icol,ilev-1,igpt);
@@ -124,7 +124,7 @@ inline void lw_transport_noscat(int ncol, int nlay, int ngpt, bool top_at_1, rea
       for (int ilev=nlay; ilev>=1; ilev--) {
         radn_up(icol,ilev,igpt) = trans(icol,ilev  ,igpt)*radn_up(icol,ilev+1,igpt) + source_up(icol,ilev,igpt);
       }
-    });
+    }));
   } else {
     // Top of domain is index nlay+1
     #ifdef RRTMGP_CPU_KERNELS
@@ -159,7 +159,7 @@ inline void lw_transport_noscat(int ncol, int nlay, int ngpt, bool top_at_1, rea
     #else
       // do igpt = 1, ngpt
       //   do icol = 1, ncol
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(ngpt,ncol) , YAKL_LAMBDA (int igpt, int icol) {
         // Downward propagation
         for (int ilev=nlay; ilev>=1; ilev--) {
           radn_dn(icol,ilev,igpt) = trans(icol,ilev  ,igpt)*radn_dn(icol,ilev+1,igpt) + source_dn(icol,ilev,igpt);
@@ -172,7 +172,7 @@ inline void lw_transport_noscat(int ncol, int nlay, int ngpt, bool top_at_1, rea
         for (int ilev=2; ilev<=nlay+1; ilev++) {
           radn_up(icol,ilev,igpt) = trans(icol,ilev-1,igpt) * radn_up(icol,ilev-1,igpt) +  source_up(icol,ilev-1,igpt);
         }
-      });
+      }));
     #endif
   }
 }
@@ -197,14 +197,14 @@ inline void sw_two_stream(int ncol, int nlay, int ngpt, real1d const &mu0, real3
 
   real eps = std::numeric_limits<real>::epsilon();
 
-  parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA (int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , ncol , YAKL_LAMBDA (int icol) {
     mu0_inv(icol) = 1./mu0(icol);
-  });
+  }));
 
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(ngpt,nlay,ncol) , YAKL_LAMBDA (int igpt, int ilay, int icol) {
     // Zdunkowski Practical Improved Flux Method "PIFM"
     //  (Zdunkowski et al., 1980;  Contributions to Atmospheric Physics 53, 147-66)
     real gamma1= (8. - w0(icol,ilay,igpt) * (5. + 3. * g(icol,ilay,igpt))) * .25;
@@ -265,7 +265,7 @@ inline void sw_two_stream(int ncol, int nlay, int ngpt, real1d const &mu0, real3
                          (1. - k_mu) * (alpha1 - k_gamma4) * exp_minus2ktau * Tnoscat(icol,ilay,igpt) -
                           2.0 * (k_gamma4 + alpha1 * k_mu)  * exp_minusktau );
 
-  });
+  }));
 }
 
 

--- a/cpp/rte/kernels/mo_rte_solver_kernels.h
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.h
@@ -910,7 +910,7 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, DT const &D, 
   // do igpt = 1, ngpt
   //   do ilev = 1, nlay+1
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay+1,ncol}) , KOKKOS_LAMBDA (int igpt, int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay+1,ngpt}) , KOKKOS_LAMBDA (int icol, int ilev, int igpt) {
     radn_dn(icol,ilev,igpt) = 2. * pi * weights(weight_ind) * radn_dn(icol,ilev,igpt);
     radn_up(icol,ilev,igpt) = 2. * pi * weights(weight_ind) * radn_up(icol,ilev,igpt);
   }));

--- a/cpp/rte/kernels/mo_rte_solver_kernels.h
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.h
@@ -881,7 +881,12 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, DT const &D, 
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  Kokkos::Array<int, 3> dims3_ngpt_nlay_ncol = {ncol,nlay,ngpt};
+  const int dims3_ngpt_nlay_ncol_tot = ngpt * nlay * ncol;
+  //TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( dims3_ngpt_nlay_ncol_tot , KOKKOS_LAMBDA (int idx) {
+    int icol, ilay, igpt;
+    conv::unflatten_idx_left(idx, dims3_ngpt_nlay_ncol, icol, ilay, igpt);
     // Optical path and transmission, used in source function and transport calculations
     tau_loc(icol,ilay,igpt) = tau(icol,ilay,igpt)*D(icol,igpt);
     trans  (icol,ilay,igpt) = exp(-tau_loc(icol,ilay,igpt));

--- a/cpp/rte/kernels/mo_rte_solver_kernels.h
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.h
@@ -411,7 +411,7 @@ inline void sw_source_2str(int ncol, int nlay, int ngpt, bool top_at_1, RdirT co
   if (top_at_1) {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<2>({ncol, ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       for (int ilev=0; ilev<nlay; ilev++) {
         source_up(icol,ilev,igpt)     =    Rdir(icol,ilev,igpt) * flux_dn_dir(icol,ilev,igpt);
         source_dn(icol,ilev,igpt)     =    Tdir(icol,ilev,igpt) * flux_dn_dir(icol,ilev,igpt);
@@ -426,7 +426,7 @@ inline void sw_source_2str(int ncol, int nlay, int ngpt, bool top_at_1, RdirT co
     // previous level is up (+1)
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<2>({ncol,ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       for (int ilev=nlay-1; ilev>=0; ilev--) {
         source_up(icol,ilev,igpt)   =    Rdir(icol,ilev,igpt) * flux_dn_dir(icol,ilev+1,igpt);
         source_dn(icol,ilev,igpt)   =    Tdir(icol,ilev,igpt) * flux_dn_dir(icol,ilev+1,igpt);
@@ -522,7 +522,7 @@ inline void sw_two_stream(int ncol, int nlay, int ngpt, Mu0T const &mu0, TauT co
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     // Zdunkowski Practical Improved Flux Method "PIFM"
     //  (Zdunkowski et al., 1980;  Contributions to Atmospheric Physics 53, 147-66)
     RealT gamma1= (8. - w0(icol,ilay,igpt) * (5. + 3. * g(icol,ilay,igpt))) * .25;

--- a/cpp/rte/mo_optical_props.h
+++ b/cpp/rte/mo_optical_props.h
@@ -42,16 +42,16 @@ public:
       #endif
       // for (int j=1; j <= size(band_lims_gpt,2); j++) {
       //   for (int i=1; i <= size(band_lims_gpt,1); i++) {
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(size(band_lims_gpt,2),size(band_lims_gpt,1)) , YAKL_LAMBDA (int j, int i) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>(size(band_lims_gpt,2),size(band_lims_gpt,1)) , YAKL_LAMBDA (int j, int i) {
         band_lims_gpt_lcl(i,j) = band_lims_gpt(i,j);
-      });
+      }));
     } else {
       // Assume that values are defined by band, one g-point per band
       // for (int iband = 1; iband <= size(band_lims_wvn, 2); iband++) {
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(size(band_lims_wvn, 2)) , YAKL_LAMBDA (int iband) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(size(band_lims_wvn, 2)) , YAKL_LAMBDA (int iband) {
         band_lims_gpt_lcl(2,iband) = iband;
         band_lims_gpt_lcl(1,iband) = iband;
-      });
+      }));
     }
     // Assignment
     this->band2gpt      = band_lims_gpt_lcl;
@@ -64,13 +64,13 @@ public:
     this->gpt2band = int1d("gpt2band",maxval(band_lims_gpt_lcl));
     // TODO: I didn't want to bother with race conditions at the moment, so it's an entirely serialized kernel for now
     YAKL_SCOPE( this_gpt2band , this->gpt2band );
-    parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(1) , YAKL_LAMBDA (int dummy) {
+    TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(1) , YAKL_LAMBDA (int dummy) {
       for (int iband=1; iband <= size(band_lims_gpt_lcl,2); iband++) {
         for (int i=band_lims_gpt_lcl(1,iband); i <= band_lims_gpt_lcl(2,iband); i++) {
           this_gpt2band(i) = iband;
         }
       }
-    });
+    }));
   }
 
   void init(OpticalProps const &in) {
@@ -148,13 +148,13 @@ public:
     //   for (int i = 1; i <= size(band_lims_wvn,1); i++) {
     YAKL_SCOPE( this_band_lims_wvn , this->band_lims_wvn );
     if (this->is_initialized()) {
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>( size(band_lims_wvn,2) , size(band_lims_wvn,1) ) , YAKL_LAMBDA (int j, int i) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>( size(band_lims_wvn,2) , size(band_lims_wvn,1) ) , YAKL_LAMBDA (int j, int i) {
         ret(i,j) = 1. / this_band_lims_wvn(i,j);
-      });
+      }));
     } else {
-      parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>( size(band_lims_wvn,2) , size(band_lims_wvn,1) ) , YAKL_LAMBDA (int j, int i) {
+      TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<2>( size(band_lims_wvn,2) , size(band_lims_wvn,1) ) , YAKL_LAMBDA (int j, int i) {
         ret(i,j) = 0.;
-      });
+      }));
     }
     return ret;
   }
@@ -172,11 +172,11 @@ public:
     // //   for (int i=1 ; i <= size(this->band_lims_wvn,1); i++) {
     // auto &this_band_lims_wvn = this->band_lims_wvn;
     // auto &rhs_band_lims_wvn  = rhs.band_lims_wvn;
-    // parallel_for( YAKL_AUTO_LABEL() , Bounds<2>( size(this->band_lims_wvn,2) , size(this->band_lims_wvn,1) ) , YAKL_LAMBDA (int j, int i) {
+    // TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<2>( size(this->band_lims_wvn,2) , size(this->band_lims_wvn,1) ) , YAKL_LAMBDA (int j, int i) {
     //   if ( std::abs( this_band_lims_wvn(i,j) - rhs_band_lims_wvn(i,j) ) > 5*epsilon(this_band_lims_wvn) ) {
     //     ret = false;
     //   }
-    // });
+    // }));
     // return ret.hostRead();
 
 
@@ -208,9 +208,9 @@ public:
     // // for (int i=1; i <= size(this->gpt2bnd,1); i++) {
     // auto &this_gpt2band = this->gpt2band;
     // auto &rhs_gpt2band  = rhs.gpt2band;
-    // parallel_for( YAKL_AUTO_LABEL() , Bounds<1>(size(this->gpt2band,1)) , YAKL_LAMBDA (int i) {
+    // TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<1>(size(this->gpt2band,1)) , YAKL_LAMBDA (int i) {
     //   if ( this_gpt2band(i) != rhs_gpt2band(i) ) { ret = false; }
-    // });
+    // }));
     // return ret.hostRead();
 
 
@@ -233,13 +233,13 @@ public:
   //   // TODO: I don't know if this needs to be serialize or not at first glance. Need to look at it more.
   //   auto &this_band2gpt = this->gpt2band;
   //   int nband = get_nband();
-  //   parallel_for( YAKL_AUTO_LABEL() , Bounds<1>(1) , YAKL_LAMBDA (int dummy) {
+  //   TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<1>(1) , YAKL_LAMBDA (int dummy) {
   //     for (int iband = 1 ; iband <= nband ; iband++) {
   //       for (int i=this_band2gpt(1,iband) ; i <= this_band2gpt(2,iband) ; i++) {
   //         ret(i) = arr_in(iband);
   //       }
   //     }
-  //   });
+  //   }));
   //   return ret;
   // }
 

--- a/cpp/rte/mo_optical_props.h
+++ b/cpp/rte/mo_optical_props.h
@@ -274,23 +274,23 @@ public:
   static inline void init_band_lims(const BandLimsT& band_lims)
   {
     // Assume that values are defined by band, one g-point per band
-    Kokkos::parallel_for( band_lims.extent(1), KOKKOS_LAMBDA (size_t iband) {
+    TIMED_KERNEL(Kokkos::parallel_for( band_lims.extent(1), KOKKOS_LAMBDA (size_t iband) {
       band_lims(1,iband) = iband;
       band_lims(0,iband) = iband;
-    });
+    }));
   }
 
   template <typename BandLimsT, typename Gpt2BandT>
   static inline void set_gpt2band(const BandLimsT& band_lims, const Gpt2BandT& gpt2band)
   {
     // TODO: I didn't want to bother with race conditions at the moment, so it's an entirely serialized kernel for now
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int dummy) {
+    TIMED_KERNEL(Kokkos::parallel_for(1, KOKKOS_LAMBDA(int dummy) {
       for (int iband=0; iband < band_lims.extent(1); iband++) {
         for (int i=band_lims(0,iband); i <= band_lims(1,iband); i++) {
           gpt2band(i) = iband;
         }
       }
-    });
+    }));
   }
 
   template <typename BandLimsWvnT, typename BandLimsGptT=view_t<int**>,
@@ -373,13 +373,13 @@ public:
     //   for (int i = 1; i <= size(band_lims_wvn,1); i++) {
     auto this_band_lims_wvn = this->band_lims_wvn;
     if (this->is_initialized()) {
-      Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(1) , band_lims_wvn.extent(0)}) , KOKKOS_LAMBDA (int j, int i) {
+      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(1) , band_lims_wvn.extent(0)}) , KOKKOS_LAMBDA (int j, int i) {
         ret(i,j) = 1. / this_band_lims_wvn(i,j);
-      });
+      }));
     } else {
-      Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(1) , band_lims_wvn.extent(0)}) , KOKKOS_LAMBDA (int j, int i) {
+      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(1) , band_lims_wvn.extent(0)}) , KOKKOS_LAMBDA (int j, int i) {
         ret(i,j) = 0.;
-      });
+      }));
     }
     return ret;
   }

--- a/cpp/rte/mo_rte_lw.h
+++ b/cpp/rte/mo_rte_lw.h
@@ -131,10 +131,10 @@ void rte_lw(int max_gauss_pts, real2d const &gauss_Ds, real2d const &gauss_wts, 
   real1d tmp_Ds ("tmp_Ds" ,n_quad_angs);
   real1d tmp_wts("tmp_wts",n_quad_angs);
   // for (int i=1 ; i <= n_quad_angs ; i++) {
-  parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(n_quad_angs) , YAKL_LAMBDA (int i) {
+  TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<1>(n_quad_angs) , YAKL_LAMBDA (int i) {
     tmp_Ds (i) = gauss_Ds (i,n_quad_angs);
     tmp_wts(i) = gauss_wts(i,n_quad_angs);
-  });
+  }));
   lw_solver_noscat_GaussQuad(ncol, nlay, ngpt, top_at_1, n_quad_angs, tmp_Ds, tmp_wts, optical_props.tau,
                              sources.lay_source, sources.lev_source_inc, sources.lev_source_dec,
                              sfc_emis_gpt, sources.sfc_source, gpt_flux_up, gpt_flux_dn);

--- a/cpp/rte/mo_rte_lw.h
+++ b/cpp/rte/mo_rte_lw.h
@@ -226,10 +226,10 @@ void rte_lw(int max_gauss_pts, GaussDsT const &gauss_Ds, GaussWtsT const &gauss_
   // No scattering two-stream calculation
   optical_props.validate();
   // for (int i=1 ; i <= n_quad_angs ; i++) {
-  Kokkos::parallel_for( n_quad_angs , KOKKOS_LAMBDA (int i) {
+  TIMED_KERNEL(Kokkos::parallel_for( n_quad_angs , KOKKOS_LAMBDA (int i) {
     tmp_Ds (i) = gauss_Ds (i,n_quad_angs - 1);
     tmp_wts(i) = gauss_wts(i,n_quad_angs - 1);
-  });
+  }));
   lw_solver_noscat_GaussQuad(ncol, nlay, ngpt, top_at_1, n_quad_angs, tmp_Ds, tmp_wts, optical_props.tau,
                              sources.lay_source, sources.lev_source_inc, sources.lev_source_dec,
                              sfc_emis_gpt, sources.sfc_source, gpt_flux_up, gpt_flux_dn);

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -15,7 +15,7 @@ if (RRTMGP_ENABLE_KOKKOS)
   add_definitions("-DRRTMGP_ENABLE_KOKKOS")
 endif()
 
-set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD 20)
 
 # Build RRTMGP, YAKL, and the standalone allsky code (which depends on both)
 # NOTE: ideally, we would build RRTMGP as a library and link allsky against it,

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -15,7 +15,7 @@ if (RRTMGP_ENABLE_KOKKOS)
   add_definitions("-DRRTMGP_ENABLE_KOKKOS")
 endif()
 
-set (CMAKE_CXX_STANDARD 20)
+set (CMAKE_CXX_STANDARD 17)
 
 # Build RRTMGP, YAKL, and the standalone allsky code (which depends on both)
 # NOTE: ideally, we would build RRTMGP as a library and link allsky against it,

--- a/cpp/test/build/reanalyze.sh
+++ b/cpp/test/build/reanalyze.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -ex
+
+this_dir=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+# rebuild
+make -j20
+
+# remove prior files
+/bin/rm -f *JGF*
+
+OMP_NUM_THREADS=64 $this_dir/test_lw_perf.sh 100 | grep TIMING > TIME_DATA_JGF
+
+$this_dir/rrtmgp-perf-analysis TIME_DATA_JGF > ANALYSIS_JGF
+
+$this_dir/rrtmgp-perf-analysis ANALYSIS_JGF KANAL_ORIG

--- a/cpp/test/build/reanalyze.sh
+++ b/cpp/test/build/reanalyze.sh
@@ -8,7 +8,7 @@ make -j20
 # remove prior files
 /bin/rm -f *JGF*
 
-OMP_NUM_THREADS=64 $this_dir/test_lw_perf.sh 100 | grep TIMING > TIME_DATA_JGF
+OMP_NUM_THREADS=64 $this_dir/test_sw_perf.sh 100 | grep TIMING > TIME_DATA_JGF
 
 $this_dir/rrtmgp-perf-analysis TIME_DATA_JGF > ANALYSIS_JGF
 

--- a/cpp/test/build/rrtmgp-perf-analysis
+++ b/cpp/test/build/rrtmgp-perf-analysis
@@ -1,0 +1,81 @@
+#! /usr/bin/env python3
+
+"""
+Given a data file, produce info. The data file can be obtained by enabling
+in rrtmgp_conversion.h then running one of the test_XX_perf.sh programs,
+grepping for TIMING, then redirecting that output to a file. Example:
+
+% OMP_NUM_THREADS=64 ../test_lw_perf.sh 100 | grep TIMING > TIME_DATA
+"""
+
+import argparse, sys
+from pathlib import Path
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n{0} <TIMING_FILE>
+OR
+{0} --help
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Analyze TIMING_FILE \033[0m
+    > {0} TIMING_FILE
+""".format(Path(args[0]).name),
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("timing_file", help="The timing file to analyze")
+
+    args = parser.parse_args(args[1:])
+
+    return args
+
+###############################################################################
+def rrtmgp_perf_analysis(timing_file):
+###############################################################################
+    raw = {}
+    lines = open(timing_file, "r").readlines()
+    for line in lines:
+        line = line.strip()
+        if line != "":
+            tokens = line.split()
+            assert len(tokens) == 10, r"Bad line '{line}', expected 10 tokens"
+            filename = tokens[3].strip(",").split("../../")[-1]
+            line     = int(tokens[5].strip(","))
+            timelen  = float(tokens[-2])
+            keystr   = f"{filename}:{line}"
+            raw[keystr] = timelen
+
+    # Inverse raw and resolve potential time collisions
+    inverse_dict = {}
+    for keystr, timelen in raw.items():
+        while timelen in inverse_dict:
+            timelen += 0.000000001
+
+        inverse_dict[timelen] = keystr
+
+    assert len(inverse_dict) == len(raw), f"Num entries should have matched, {len(inverse_dict)} != {len(raw)}"
+
+    total_time = 0.0
+    for timelen, keystr in reversed(sorted(inverse_dict.items())):
+        print(f"{keystr} => {timelen}")
+        total_time += timelen
+
+    print(f"Total time spent in kernels: {total_time}")
+
+    return True
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    success = rrtmgp_perf_analysis(**vars(parse_command_line(sys.argv, description)))
+
+    sys.exit(0 if success else 1)
+
+###############################################################################
+
+if __name__ == "__main__":
+    _main_func(__doc__)

--- a/cpp/test/build/rrtmgp-perf-analysis
+++ b/cpp/test/build/rrtmgp-perf-analysis
@@ -6,6 +6,15 @@ in rrtmgp_conversion.h then running one of the test_XX_perf.sh programs,
 grepping for TIMING, then redirecting that output to a file. Example:
 
 % OMP_NUM_THREADS=64 ../test_lw_perf.sh 100 | grep TIMING > TIME_DATA
+% rrtmgp_perf_analysis TIME_DATA
+
+To compare against baseline results:
+% OMP_NUM_THREADS=64 ../test_lw_perf.sh 100 | grep TIMING > BASELINE_DATA
+% rrtmgp_perf_analysis BASELINE_DATA > BASELINE_ANALYSIS
+* Make changes *
+% OMP_NUM_THREADS=64 ../test_lw_perf.sh 100 | grep TIMING > NEW_DATA
+% rrtmgp_perf_analysis NEW_DATA > NEW_ANALYSIS
+% rrtmgp_perf_analysis NEW_DATA BASELINE_DATA
 """
 
 import argparse, sys, os
@@ -27,7 +36,7 @@ OR
     > {0} KANALYZED YANALYZED
 """.format(Path(args[0]).name),
         description=description,
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        formatter_class=argparse.RawDescriptionHelpFormatter
     )
 
     parser.add_argument("timing_file", help="The timing file to analyze (or analysis file if 2 args)")

--- a/cpp/test/build/rrtmgp-perf-analysis
+++ b/cpp/test/build/rrtmgp-perf-analysis
@@ -22,12 +22,17 @@ OR
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Analyze TIMING_FILE \033[0m
     > {0} TIMING_FILE
+
+    \033[1;32m# Compare two analyzed files \033[0m
+    > {0} KANALYZED YANALYZED
 """.format(Path(args[0]).name),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    parser.add_argument("timing_file", help="The timing file to analyze")
+    parser.add_argument("timing_file", help="The timing file to analyze (or analysis file if 2 args)")
+
+    parser.add_argument("compare_file", nargs="?", help="The second analysis file")
 
     args = parser.parse_args(args[1:])
 
@@ -47,7 +52,7 @@ def rrtmgp_perf_analysis(timing_file):
             filename = os.path.splitext("/".join(tokens[5].split("/")[-2:]))[0]
             line     = int(tokens[7])
             timelen  = float(tokens[-2])
-            keystr   = f"{filename}:{line}"
+            keystr   = f"{filename}:{funcname}:{line}"
             raw[keystr] = timelen
 
     # Inverse raw and resolve potential time collisions
@@ -70,9 +75,105 @@ def rrtmgp_perf_analysis(timing_file):
     return True
 
 ###############################################################################
+def parse_analysis(analysis_file):
+###############################################################################
+    lines = open(analysis_file, "r").readlines()
+    result = []
+    for line in lines:
+        line = line.strip()
+        if line != "" and "Total time" not in line:
+            megatokens = line.split(" => ")
+            assert len(megatokens) == 2, f"Bad line, expected 2 megatokens: {line}"
+            location, timelen = megatokens
+            timelen = float(timelen)
+            tokens = location.split(":")
+            assert len(tokens) == 3, f"Bad location, expected 3 tokens: {location}"
+            filename, funcname, lineno = tokens
+            lineno = int(lineno)
+            result.append((filename, funcname, lineno, timelen))
+
+    return result
+
+###############################################################################
+def get_id_map(analysis_raw):
+###############################################################################
+    """
+    Returns {filename+funcname => {lineno => timelen}} where the inner dict
+    is sorted by lineno. This will be used to give kernels IDs based on their
+    location. The ID will be N where N is the Nth-kernel of a function (ordered
+    by line number).
+    """
+    result = {}
+    for filename, funcname, lineno, timelen in analysis_raw:
+        outer_key = f"{filename}:{funcname}"
+        if outer_key not in result:
+            result[outer_key] = {}
+
+        inner_dict = result[outer_key]
+        assert lineno not in inner_dict, f"{lineno} appears twice in {outer_key}"
+        inner_dict[lineno] = timelen
+
+        # Make sure it stays sorted
+        result[outer_key] = dict(sorted(inner_dict.items()))
+
+    return result
+
+###############################################################################
+def get_id(filename, funcname, lineno, id_map):
+###############################################################################
+    outer_key = f"{filename}:{funcname}"
+    inner_dict = id_map[outer_key]
+    for idx, curr_lineno in enumerate(inner_dict.keys()):
+        if curr_lineno == lineno:
+            return idx
+
+    assert False, f"Failed to find kernel {filename} {funcname} {lineno}"
+    return None
+
+###############################################################################
+def get_kernel_by_id(filename, funcname, kernel_id, id_map):
+###############################################################################
+    outer_key = f"{filename}:{funcname}"
+    if outer_key in id_map:
+        inner_dict = id_map[outer_key]
+        for idx, dpair in enumerate(inner_dict.items()):
+            if idx == kernel_id:
+                return dpair
+
+    print(f"WARNING: Failed to find comparison kernel for {filename} {funcname} {kernel_id}")
+    return None
+
+###############################################################################
+def compare_analyses(file1, file2):
+###############################################################################
+    analysis1_raw = parse_analysis(file1)
+    analysis2_raw = parse_analysis(file2)
+
+    id_map1 = get_id_map(analysis1_raw)
+    id_map2 = get_id_map(analysis2_raw)
+
+    for filename, funcname, lineno, timelen in analysis1_raw:
+        kernel_id = get_id(filename, funcname, lineno, id_map1)
+        other_kernel = get_kernel_by_id(filename, funcname, kernel_id, id_map2)
+        if other_kernel is not None:
+            other_lineno, other_timelen = other_kernel
+            changepct = (timelen / other_timelen) * 100
+            print(f"{filename}:{funcname}:{lineno} => {timelen} (changepct={changepct:.2f}) (other lineno={other_lineno})")
+
+    return True
+
+###############################################################################
+def dispatch(timing_file, compare_file):
+###############################################################################
+    if compare_file is None:
+        return rrtmgp_perf_analysis(timing_file)
+    else:
+        return compare_analyses(timing_file, compare_file)
+
+###############################################################################
 def _main_func(description):
 ###############################################################################
-    success = rrtmgp_perf_analysis(**vars(parse_command_line(sys.argv, description)))
+    success = dispatch(**vars(parse_command_line(sys.argv, description)))
 
     sys.exit(0 if success else 1)
 

--- a/cpp/test/build/rrtmgp-perf-analysis
+++ b/cpp/test/build/rrtmgp-perf-analysis
@@ -8,7 +8,7 @@ grepping for TIMING, then redirecting that output to a file. Example:
 % OMP_NUM_THREADS=64 ../test_lw_perf.sh 100 | grep TIMING > TIME_DATA
 """
 
-import argparse, sys
+import argparse, sys, os
 from pathlib import Path
 
 ###############################################################################
@@ -42,9 +42,10 @@ def rrtmgp_perf_analysis(timing_file):
         line = line.strip()
         if line != "":
             tokens = line.split()
-            assert len(tokens) == 10, r"Bad line '{line}', expected 10 tokens"
-            filename = tokens[3].strip(",").split("../../")[-1]
-            line     = int(tokens[5].strip(","))
+            assert len(tokens) == 11, r"Bad line '{line}', expected 11 tokens"
+            funcname = tokens[3]
+            filename = os.path.splitext("/".join(tokens[5].split("/")[-2:]))[0]
+            line     = int(tokens[7])
             timelen  = float(tokens[-2])
             keystr   = f"{filename}:{line}"
             raw[keystr] = timelen

--- a/cpp/test/build/rrtmgp-perf-analysis
+++ b/cpp/test/build/rrtmgp-perf-analysis
@@ -146,6 +146,11 @@ def get_kernel_by_id(filename, funcname, kernel_id, id_map):
 ###############################################################################
 def compare_analyses(file1, file2):
 ###############################################################################
+    CEND      = '\33[0m'
+    CBOLD     = '\33[1m'
+    CRED      = '\33[31m'
+    CGREEN    = '\33[32m'
+
     analysis1_raw = parse_analysis(file1)
     analysis2_raw = parse_analysis(file2)
 
@@ -158,7 +163,14 @@ def compare_analyses(file1, file2):
         if other_kernel is not None:
             other_lineno, other_timelen = other_kernel
             changepct = (timelen / other_timelen) * 100
-            print(f"{filename}:{funcname}:{lineno} => {timelen} (changepct={changepct:.2f}) (other lineno={other_lineno})")
+            output_style = ""
+            if changepct > 125:
+                output_style = CBOLD + CRED
+            elif changepct < 75:
+                output_style = CBOLD + CGREEN
+
+            style_end = "" if output_style == "" else CEND
+            print(f"{filename}:{funcname}:{lineno} => {timelen} (changepct={output_style}{changepct:.2f}{style_end}) (other lineno={other_lineno})")
 
     return True
 


### PR DESCRIPTION
On weaver after opts with kokkos:
```
Kokkos:: Longwave  did 100 loops of 1000 cols and 42 layers in 0.989172 s
YAKL::   Longwave  did 100 loops of 1000 cols and 42 layers in 0.992474 s
Kokkos:: Shortwave did 100 loops of 1000 cols and 42 layers in 1.058807 s
YAKL::   Shortwave did 100 loops of 1000 cols and 42 layers in 1.085853 s
```

So, Kokkos is now slightly faster than YAKL on GPU. It was over 2x slower before these changes.

Methodology: A new `TIMED_KERNEL` macro enables timings for all kernels, both YAKL and Kokkos. When this is enabled, raw data is dumped. The new tool `rrtmgp-perf-analysis` can read these raw dumps and present the user with concise, useful information, such as which kernels were taking the most time and how their perf compared to their YAKL counterparts. For most kernels that were slower than YAKL, improving perf was just a matter of rearranging the MDrange order.