### PR TITLE
De-optimize kernel for determinism

### DIFF
--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -33,7 +33,6 @@ int main(int argc , char **argv) {
   using real2d_t = Kokkos::View<real**,  LayoutT, DeviceT>;
   using real3d_t = Kokkos::View<real***, LayoutT, DeviceT>;
   using bool2d_t = Kokkos::View<bool**,  LayoutT, DeviceT>;
-  using oreal3d_t = Kokkos::Experimental::OffsetView<real***, LayoutT, DeviceT>;
   using hreal2d_t = Kokkos::View<real**, LayoutT, HostDevice>;
   using pool_t = conv::MemPoolSingleton<real, DeviceT>;
 #endif
@@ -285,7 +284,7 @@ int main(int argc , char **argv) {
       const size_t base_ref = 18000;
       const size_t my_size_ref = ncol * nlay * nlev;
       pool_t::init(2e6 * (float(my_size_ref) / base_ref));
-      oreal3d_t col_gas("col_gas", std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
+      real3d_t col_gas("col_gas", ncol, nlay, k_dist_k.get_ngas()+1);
 #endif
 
       if (verbose) std::cout << "Running the main loop\n\n";
@@ -586,7 +585,7 @@ int main(int argc , char **argv) {
       const size_t base_ref = 18000;
       const size_t my_size_ref = ncol * nlay * nlev;
       pool_t::init(2e6 * (float(my_size_ref) / base_ref));
-      oreal3d_t col_gas("col_gas", std::make_pair(0, ncol-1), std::make_pair(0, nlay-1), std::make_pair(-1, k_dist_k.get_ngas()-1));
+      real3d_t col_gas("col_gas", ncol, nlay, k_dist_k.get_ngas()+1);
 #endif
 
       // Multiple iterations for big problem sizes, and to help identify data movement

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -217,10 +217,10 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
     // compute interpolation fractions needed for lower, then upper reference temperature level
     // compute binary species parameter (eta) for flavor and temperature and
     //  associated interpolation index and factors
-    RealT ratio_eta_half = vmr_ref(itropo,igases1,(jtemp(icol,ilay)+itemp)) /
-                          vmr_ref(itropo,igases2,(jtemp(icol,ilay)+itemp));
-    col_mix(itemp,iflav,icol,ilay) = col_gas(icol,ilay,igases1) + ratio_eta_half * col_gas(icol,ilay,igases2);
-    RealT eta = merge(col_gas(icol,ilay,igases1) / col_mix(itemp,iflav,icol,ilay), 0.5,
+    RealT ratio_eta_half = vmr_ref(itropo,igases1+1,(jtemp(icol,ilay)+itemp)) /
+                          vmr_ref(itropo,igases2+1,(jtemp(icol,ilay)+itemp));
+    col_mix(itemp,iflav,icol,ilay) = col_gas(icol,ilay,igases1+1) + ratio_eta_half * col_gas(icol,ilay,igases2+1);
+    RealT eta = merge(col_gas(icol,ilay,igases1+1) / col_mix(itemp,iflav,icol,ilay), 0.5,
                      col_mix(itemp,iflav,icol,ilay) > 2. * tiny);
     RealT loceta = eta * (neta-1.0);
     jeta(itemp,iflav,icol,ilay) = Kokkos::fmin((int)(loceta)+1, neta-1) - 1;
@@ -443,7 +443,7 @@ void compute_tau_rayleigh(int ncol, int nlay, int nbnd, int ngpt, int ngas, int 
              fminor(1,0,iflav,icol,ilay) * krayl(igpt, jeta(0,iflav,icol,ilay)+1, jtemp(icol,ilay)  ,itropo) +
              fminor(0,1,iflav,icol,ilay) * krayl(igpt, jeta(1,iflav,icol,ilay)  , jtemp(icol,ilay)+1,itropo) +
              fminor(1,1,iflav,icol,ilay) * krayl(igpt, jeta(1,iflav,icol,ilay)+1, jtemp(icol,ilay)+1,itropo);
-    tau_rayleigh(igpt,ilay,icol) =  k * (col_gas(icol,ilay,idx_h2o)+col_dry(icol,ilay));
+    tau_rayleigh(igpt,ilay,icol) =  k * (col_gas(icol,ilay,idx_h2o+1)+col_dry(icol,ilay));
   }));
 }
 
@@ -483,19 +483,19 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
       RealT myplay  = play (icol,ilay);
       RealT mytlay  = tlay (icol,ilay);
       int  myjtemp = jtemp(icol,ilay);
-      RealT mycol_gas_h2o = col_gas(icol,ilay,idx_h2o);
-      RealT mycol_gas_0   = col_gas(icol,ilay,-1);
+      RealT mycol_gas_h2o = col_gas(icol,ilay,idx_h2o+1);
+      RealT mycol_gas_0   = col_gas(icol,ilay,0);
 
 // #ifndef KOKKOS_ENABLE_CUDA
       for (int imnr=0; imnr<extent; imnr++) {
 // #endif
-      RealT scaling = col_gas(icol,ilay,idx_minor(imnr));
+      RealT scaling = col_gas(icol,ilay,idx_minor(imnr)+1);
       if (minor_scales_with_density(imnr)) {
         // NOTE: P needed in hPa to properly handle density scaling.
         scaling = scaling * (PaTohPa * myplay/mytlay);
 
         if (idx_minor_scaling(imnr) > -1) {  // there is a second gas that affects this gas's absorption
-          RealT mycol_gas_imnr = col_gas(icol,ilay,idx_minor_scaling(imnr));
+          RealT mycol_gas_imnr = col_gas(icol,ilay,idx_minor_scaling(imnr)+1);
           RealT vmr_fact = 1. / mycol_gas_0;
           RealT dry_fact = 1. / (1. + mycol_gas_h2o * vmr_fact);
           // scale by density of special gas

--- a/cpp/rrtmgp_const.h
+++ b/cpp/rrtmgp_const.h
@@ -12,7 +12,6 @@
 
 #ifdef RRTMGP_ENABLE_KOKKOS
 #include <Kokkos_Core.hpp>
-#include <Kokkos_OffsetView.hpp>
 
 using DefaultDevice =
   Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>;

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -71,13 +71,12 @@ template <class T1, class T2,
           typename std::enable_if<std::is_arithmetic<T1>::value && std::is_arithmetic<T2>::value,bool>::type=false>
 GENERIC_INLINE decltype(T1()+T2()) merge(T1 const t, T2 const f, bool cond) noexcept { return cond ? t : f; }
 
-// A meta function that will return true if T is either a Kokkos::View or a
-// Kokkos::OffsetView (we use these in a couple places).
+// A meta function that will return true if T is a Kokkos::View
 template <typename T>
 struct is_view
 {
 #ifdef RRTMGP_ENABLE_KOKKOS
-  static constexpr bool value = Kokkos::is_view<T>::value || Kokkos::Experimental::is_offset_view<T>::value;
+  static constexpr bool value = Kokkos::is_view<T>::value;
 #else
   static constexpr bool value = false;
 #endif


### PR DESCRIPTION
It's a shame, this was the best optimization I was able to get in all the perf work I did earlier. There's no way to guarantee the order of the atomic adds, so it introduced non-determinism on GPU. I was trying to think of a way to do this without using hierarchical parallelism; maybe a temporary view followed by a reduce?