### PR TITLE
These changes get kokkos+rrtmgp performance on frontier to match yakl+rrtmgp

### DIFF
--- a/cpp/examples/all-sky/mo_garand_atmos_io.h
+++ b/cpp/examples/all-sky/mo_garand_atmos_io.h
@@ -39,22 +39,22 @@ void read_atmos(const std::string& input_file, ViewT &p_lay, ViewT &t_lay, ViewT
   ViewT tmp2d;
   // p_lay
   io.read(tmp2d,"p_lay");
-  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({ncol, nlay}), KOKKOS_LAMBDA (int icol, int ilay) {
     p_lay(icol,ilay) = tmp2d(0,ilay);
   }));
   // t_lay
   io.read(tmp2d,"t_lay");
-  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({ncol, nlay}), KOKKOS_LAMBDA (int icol, int ilay) {
     t_lay(icol,ilay) = tmp2d(0,ilay);
   }));
   // p_lev
   io.read(tmp2d,"p_lev");
-  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({nlev,ncol}), KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({ncol, nlev}), KOKKOS_LAMBDA (int icol, int ilev) {
     p_lev(icol,ilev) = tmp2d(0,ilev);
   }));
   // t_lev
   io.read(tmp2d,"t_lev");
-  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({nlev,ncol}), KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({ncol, nlev}), KOKKOS_LAMBDA (int icol, int ilev) {
     t_lev(icol,ilev) = tmp2d(0,ilev);
   }));
 
@@ -84,7 +84,7 @@ void read_atmos(const std::string& input_file, ViewT &p_lay, ViewT &t_lay, ViewT
     col_dry = ViewT("col_dry",ncol,nlay);
     tmp2d = ViewT();     // Reset the tmp2d variable
     io.read(tmp2d,"col_dry");
-    TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({ncol, nlay}), KOKKOS_LAMBDA (int icol, int ilay) {
       col_dry(icol,ilay) = tmp2d(0,ilay);
     }));
   }

--- a/cpp/examples/all-sky/mo_garand_atmos_io.h
+++ b/cpp/examples/all-sky/mo_garand_atmos_io.h
@@ -39,24 +39,24 @@ void read_atmos(const std::string& input_file, ViewT &p_lay, ViewT &t_lay, ViewT
   ViewT tmp2d;
   // p_lay
   io.read(tmp2d,"p_lay");
-  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({ncol, nlay}), KOKKOS_LAMBDA (int icol, int ilay) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlay, icol, ilay,
     p_lay(icol,ilay) = tmp2d(0,ilay);
-  }));
+  ));
   // t_lay
   io.read(tmp2d,"t_lay");
-  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({ncol, nlay}), KOKKOS_LAMBDA (int icol, int ilay) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlay, icol, ilay,
     t_lay(icol,ilay) = tmp2d(0,ilay);
-  }));
+  ));
   // p_lev
   io.read(tmp2d,"p_lev");
-  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({ncol, nlev}), KOKKOS_LAMBDA (int icol, int ilev) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlev, icol, ilev,
     p_lev(icol,ilev) = tmp2d(0,ilev);
-  }));
+  ));
   // t_lev
   io.read(tmp2d,"t_lev");
-  TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({ncol, nlev}), KOKKOS_LAMBDA (int icol, int ilev) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlev, icol, ilev,
     t_lev(icol,ilev) = tmp2d(0,ilev);
-  }));
+  ));
 
   std::vector<std::string> gas_names = {
     "h2o", "co2", "o3", "n2o", "co", "ch4", "o2", "n2"
@@ -84,9 +84,9 @@ void read_atmos(const std::string& input_file, ViewT &p_lay, ViewT &t_lay, ViewT
     col_dry = ViewT("col_dry",ncol,nlay);
     tmp2d = ViewT();     // Reset the tmp2d variable
     io.read(tmp2d,"col_dry");
-    TIMED_KERNEL(Kokkos::parallel_for( MDRP::template get<2>({ncol, nlay}), KOKKOS_LAMBDA (int icol, int ilay) {
+    TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlay, icol, ilay,
       col_dry(icol,ilay) = tmp2d(0,ilay);
-    }));
+    ));
   }
 
   io.close();

--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -267,7 +267,7 @@ int main(int argc , char **argv) {
       });
 #endif
 #ifdef RRTMGP_ENABLE_KOKKOS
-      Kokkos::parallel_for( MDRP::template get<2>({nlay,ncol}) , KOKKOS_LAMBDA (int ilay, int icol) {
+      Kokkos::parallel_for( MDRP::template get<2>({ncol, nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
         cloud_mask_k(icol,ilay) = p_lay_k(icol,ilay) > 100. * 100. && p_lay_k(icol,ilay) < 900. * 100. && ((icol+1) % 3) != 0;
         // Ice and liquid will overlap in a few layers
         lwp_k(icol,ilay) = merge(10.,  0., cloud_mask_k(icol,ilay) && t_lay_k(icol,ilay) > 263.);
@@ -566,7 +566,7 @@ int main(int argc , char **argv) {
       });
 #endif
 #ifdef RRTMGP_ENABLE_KOKKOS
-      Kokkos::parallel_for( MDRP::template get<2>({nlay,ncol}) , KOKKOS_LAMBDA (int ilay, int icol) {
+      Kokkos::parallel_for( MDRP::template get<2>({ncol, nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
         cloud_mask_k(icol,ilay) = p_lay_k(icol,ilay) > 100. * 100. && p_lay_k(icol,ilay) < 900. * 100. && ((icol+1) % 3) != 0;
         // Ice and liquid will overlap in a few layers
         lwp_k(icol,ilay) = merge(10.,  0., cloud_mask_k(icol,ilay) && t_lay_k(icol,ilay) > 263.);

--- a/cpp/examples/all-sky/rrtmgp_allsky.cpp
+++ b/cpp/examples/all-sky/rrtmgp_allsky.cpp
@@ -34,7 +34,7 @@ int main(int argc , char **argv) {
   using real3d_t = Kokkos::View<real***, LayoutT, DeviceT>;
   using bool2d_t = Kokkos::View<bool**,  LayoutT, DeviceT>;
   using hreal2d_t = Kokkos::View<real**, LayoutT, HostDevice>;
-  using pool_t = conv::MemPoolSingleton<real, DeviceT>;
+  using pool_t = conv::MemPoolSingleton<real, LayoutT, DeviceT>;
 #endif
 
   {

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -871,7 +871,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1,ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,nbnd}), KOKKOS_LAMBDA (int icol, int ilay, int ibnd) {
       // Absorption optical depth  = (1-ssa) * tau = tau - taussa
       optical_props_tau(icol,ilay,ibnd) = (ltau(icol,ilay,ibnd) - ltaussa(icol,ilay,ibnd)) +
                                           (itau(icol,ilay,ibnd) - itaussa(icol,ilay,ibnd));
@@ -888,7 +888,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1,ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,nbnd}), KOKKOS_LAMBDA (int icol, int ilay, int ibnd) {
       RealT tau    = ltau   (icol,ilay,ibnd) + itau   (icol,ilay,ibnd);
       RealT taussa = ltaussa(icol,ilay,ibnd) + itaussa(icol,ilay,ibnd);
       optical_props_g  (icol,ilay,ibnd) = (ltaussag(icol,ilay,ibnd) + itaussag(icol,ilay,ibnd)) / Kokkos::fmax(conv::epsilon(tau), taussa);
@@ -931,7 +931,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // do ibnd = 1, nbnd
     //   do ilay = 1,nlay
     //     do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,nbnd}), KOKKOS_LAMBDA (int icol, int ilay, int ibnd) {
       if (mask(icol,ilay)) {
         int index = Kokkos::fmin( floor( (re(icol,ilay) - offset) / step_size)+1, nsteps-1.) - 1;
         RealT fint = (re(icol,ilay) - offset)/step_size - index;

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -776,7 +776,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
   template <typename ClwpT, typename CiwpT, typename ReliqT, typename ReiceT, class OpticalPropsT>
   void cloud_optics(const int ncol, const int nlay,
                     ClwpT const &clwp, CiwpT const &ciwp, ReliqT const &reliq, ReiceT const &reice, OpticalPropsT &optical_props) {
-    using pool = conv::MemPoolSingleton<RealT, DeviceT>;
+    using pool = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
 
     int nbnd = this->get_nband();
     // Error checking

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -871,7 +871,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1,ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,nbnd}), KOKKOS_LAMBDA (int icol, int ilay, int ibnd) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,nbnd}), KOKKOS_LAMBDA (int icol, int ilay, int ibnd) {
       // Absorption optical depth  = (1-ssa) * tau = tau - taussa
       optical_props_tau(icol,ilay,ibnd) = (ltau(icol,ilay,ibnd) - ltaussa(icol,ilay,ibnd)) +
                                           (itau(icol,ilay,ibnd) - itaussa(icol,ilay,ibnd));
@@ -888,7 +888,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1,ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,nbnd}), KOKKOS_LAMBDA (int icol, int ilay, int ibnd) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,nbnd}), KOKKOS_LAMBDA (int icol, int ilay, int ibnd) {
       RealT tau    = ltau   (icol,ilay,ibnd) + itau   (icol,ilay,ibnd);
       RealT taussa = ltaussa(icol,ilay,ibnd) + itaussa(icol,ilay,ibnd);
       optical_props_g  (icol,ilay,ibnd) = (ltaussag(icol,ilay,ibnd) + itaussag(icol,ilay,ibnd)) / Kokkos::fmax(conv::epsilon(tau), taussa);
@@ -931,7 +931,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // do ibnd = 1, nbnd
     //   do ilay = 1,nlay
     //     do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,nbnd}), KOKKOS_LAMBDA (int icol, int ilay, int ibnd) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,nbnd}), KOKKOS_LAMBDA (int icol, int ilay, int ibnd) {
       if (mask(icol,ilay)) {
         int index = Kokkos::fmin( floor( (re(icol,ilay) - offset) / step_size)+1, nsteps-1.) - 1;
         RealT fint = (re(icol,ilay) - offset)/step_size - index;

--- a/cpp/extensions/cloud_optics/mo_cloud_optics.h
+++ b/cpp/extensions/cloud_optics/mo_cloud_optics.h
@@ -796,7 +796,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // Cloud masks; don't need value re values if there's no cloud
     // do ilay = 1, nlay
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlay}), KOKKOS_LAMBDA (int icol, int ilay) {
       liqmsk(icol,ilay) = clwp(icol,ilay) > 0.;
       icemsk(icol,ilay) = ciwp(icol,ilay) > 0.;
     }));
@@ -959,7 +959,7 @@ class CloudOpticsK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // do ibnd = 1, nbnd
     //   do ilay = 1, nlay
     //     do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlay,ncol}), KOKKOS_LAMBDA (int ibnd, int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol, nlay, nbnd}), KOKKOS_LAMBDA (int icol, int ilay, int ibnd) {
       if (mask(icol,ilay)) {
         int irad;
         // Finds index into size regime table

--- a/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.h
+++ b/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.h
@@ -17,7 +17,7 @@ void sum_byband(int ncol, int nlev, int ngpt, int nbnd, BndLimsT const &bnd_lims
   using LayoutT = typename SpectralT::array_layout;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlev,nbnd}) , KOKKOS_LAMBDA (int icol, int ilev, int ibnd) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlev,nbnd}) , KOKKOS_LAMBDA (int icol, int ilev, int ibnd) {
     RealT bb_flux_s = 0.0;
     for (int igpt=bnd_lims(0,ibnd); igpt<=bnd_lims(1,ibnd); igpt++) {
       bb_flux_s += spectral_flux(icol,ilev,igpt);
@@ -33,7 +33,7 @@ void net_byband(int ncol, int nlev, int nbnd,
   using LayoutT = typename FluxDnT::array_layout;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlev,nbnd}) , KOKKOS_LAMBDA (int icol, int ilev, int ibnd) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlev,nbnd}) , KOKKOS_LAMBDA (int icol, int ilev, int ibnd) {
     bnd_flux_net(icol,ilev,ibnd) = bnd_flux_dn(icol,ilev,ibnd) - bnd_flux_up(icol,ilev,ibnd);
   }));
 }

--- a/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.h
+++ b/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.h
@@ -17,7 +17,7 @@ void sum_byband(int ncol, int nlev, int ngpt, int nbnd, BndLimsT const &bnd_lims
   using LayoutT = typename SpectralT::array_layout;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlev,ncol}) , KOKKOS_LAMBDA (int ibnd, int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlev,nbnd}) , KOKKOS_LAMBDA (int icol, int ilev, int ibnd) {
     RealT bb_flux_s = 0.0;
     for (int igpt=bnd_lims(0,ibnd); igpt<=bnd_lims(1,ibnd); igpt++) {
       bb_flux_s += spectral_flux(icol,ilev,igpt);
@@ -33,8 +33,8 @@ void net_byband(int ncol, int nlev, int nbnd,
   using LayoutT = typename FluxDnT::array_layout;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({nbnd,nlev,ncol}) , KOKKOS_LAMBDA (int ibnd, int ilev, int icol) {
-      bnd_flux_net(icol,ilev,ibnd) = bnd_flux_dn(icol,ilev,ibnd) - bnd_flux_up(icol,ilev,ibnd);
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlev,nbnd}) , KOKKOS_LAMBDA (int icol, int ilev, int ibnd) {
+    bnd_flux_net(icol,ilev,ibnd) = bnd_flux_dn(icol,ilev,ibnd) - bnd_flux_up(icol,ilev,ibnd);
   }));
 }
 #endif

--- a/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.h
+++ b/cpp/extensions/fluxes_byband/mo_fluxes_byband_kernels.h
@@ -17,13 +17,13 @@ void sum_byband(int ncol, int nlev, int ngpt, int nbnd, BndLimsT const &bnd_lims
   using LayoutT = typename SpectralT::array_layout;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlev,nbnd}) , KOKKOS_LAMBDA (int icol, int ilev, int ibnd) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL3(ncol,nlev,nbnd, icol, ilev, ibnd,
     RealT bb_flux_s = 0.0;
     for (int igpt=bnd_lims(0,ibnd); igpt<=bnd_lims(1,ibnd); igpt++) {
       bb_flux_s += spectral_flux(icol,ilev,igpt);
     }
     byband_flux(icol,ilev,ibnd) = bb_flux_s;
-  }));
+  ));
 }
 // Compute net flux
 template <typename FluxDnT, typename FluxUpT, typename FluxNetT>
@@ -33,8 +33,8 @@ void net_byband(int ncol, int nlev, int nbnd,
   using LayoutT = typename FluxDnT::array_layout;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlev,nbnd}) , KOKKOS_LAMBDA (int icol, int ilev, int ibnd) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL3(ncol,nlev,nbnd, icol, ilev, ibnd,
     bnd_flux_net(icol,ilev,ibnd) = bnd_flux_dn(icol,ilev,ibnd) - bnd_flux_up(icol,ilev,ibnd);
-  }));
+  ));
 }
 #endif

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -193,7 +193,7 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
 
   // for (int ilay=1; ilay<=nlay; ilay++) {
   //   for (int icol=1; icol<=ncol; icol++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlay,ncol}) , KOKKOS_LAMBDA (int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
     // index and factor for temperature interpolation
     jtemp(icol,ilay) = (int) ((tlay(icol,ilay) - (temp_ref_min - temp_ref_delta)) / temp_ref_delta);
     jtemp(icol,ilay) = Kokkos::fmin(ntemp - 1, Kokkos::fmax(1, jtemp(icol,ilay))) - 1; // limit the index range

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -180,7 +180,7 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
   using DeviceT = typename JtempT::device_type;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
-  using pool = conv::MemPoolSingleton<RealT, DeviceT>;
+  using pool = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
 
   using ureal2d_t = conv::Unmanaged<Kokkos::View<RealT**, LayoutT, DeviceT>>;
 
@@ -288,7 +288,7 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   using LayoutT = typename JtempT::array_layout;
   using DeviceT = typename JtempT::device_type;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
-  using pool = conv::MemPoolSingleton<RealT, DeviceT>;
+  using pool = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
 
   using ureal3d_t = conv::Unmanaged<Kokkos::View<RealT***, LayoutT, DeviceT>>;
 
@@ -598,7 +598,7 @@ void compute_tau_absorption(int max_gpt_diff_lower, int max_gpt_diff_upper, int 
   using RealT   = typename TauT::non_const_value_type;
   using LayoutT = typename TauT::array_layout;
   using DeviceT = typename TauT::device_type;
-  using pool = conv::MemPoolSingleton<RealT, DeviceT>;
+  using pool = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
 
   using uint2d_t = conv::Unmanaged<Kokkos::View<int**, LayoutT, DeviceT>>;
 

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -255,9 +255,6 @@ void combine_and_reorder_2str(int ncol, int nlay, int ngpt, TauAbsT const &tau_a
   //     for (int tgpt=1; tgpt<=gptTiles; tgpt++) {
   //       for (int itcol=1; itcol<=TILE_SIZE; itcol++) {
   //         for (int itgpt=1; itgpt<=TILE_SIZE; itgpt++) {
-  // TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<5>({nlay,colTiles,gptTiles,TILE_SIZE,TILE_SIZE}) , KOKKOS_LAMBDA (int ilay, int tcol, int tgpt, int itcol, int itgpt) {
-  //   int icol = tcol*TILE_SIZE + itcol;
-  //   int igpt = tgpt*TILE_SIZE + itgpt;
   TIMED_KERNEL(FLATTEN_MD_KERNEL3(ncol,nlay,ngpt, icol, ilay, igpt,
     RealT t = tau_abs(igpt,ilay,icol) + tau_rayleigh(igpt,ilay,icol);
     tau(icol,ilay,igpt) = t;
@@ -296,9 +293,6 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   // for (int icol=1; icol<=ncol; icol++) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  // TIMED_KERNEL(Kokkos::parallel_for( dims3_tot, KOKKOS_LAMBDA (int idx) {
-  //   int ilay, icol, igpt;
-  //   conv::unflatten_idx(idx, dims3_nlay_ncol_ngpt, ilay, icol, igpt);
   TIMED_KERNEL(FLATTEN_MD_KERNEL3(ngpt,ncol,nlay, igpt, icol, ilay,
     // itropo = 0 lower atmosphere; itropo = 1 upper atmosphere
     int itropo = merge(0,1,tropo(icol,ilay));  //WS moved itropo inside loop for GPU
@@ -332,22 +326,12 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   //
   // for (int igpt=1; igpt<=ngpt; igpt++) {
   //   for (int icol=1; icol<=ncol; icol++) {
-  // Kokkos::Array<int, 2> dims2_ngpt_ncol = {ngpt,ncol};
-  // const int dims2_ngpt_ncol_tot = ncol*ngpt;
-  // TIMED_KERNEL(Kokkos::parallel_for( dims2_ngpt_ncol_tot, KOKKOS_LAMBDA (int idx) {
-  //   int igpt, icol;
-  //   conv::unflatten_idx(idx, dims2_ngpt_ncol, igpt, icol);
   TIMED_KERNEL(FLATTEN_MD_KERNEL2(ngpt,ncol, igpt, icol,
     sfc_src(igpt,icol) = pfrac(igpt,sfc_lay,icol) * planck_function(gpoint_bands(igpt), 0, icol);
   ));
 
   // for (int icol=1; icol<=ncol; icol++) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
-  // Kokkos::Array<int, 2> dims2_ncol_nlay = {ncol,nlay};
-  // const int dims2_ncol_nlay_tot = ncol*nlay;
-  // TIMED_KERNEL(Kokkos::parallel_for( dims2_ncol_nlay_tot, KOKKOS_LAMBDA (int idx) {
-  //   int icol, ilay;
-  //   conv::unflatten_idx(idx, dims2_ncol_nlay, icol, ilay);
   TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol,nlay, icol, ilay,
     // Compute layer source irradiance for g-point, equals band irradiance x fraction for g-point
     interpolate1D(tlay(icol,ilay), temp_ref_min, totplnk_delta, totplnk, Kokkos::subview(planck_function, Kokkos::ALL,ilay,icol),nPlanckTemp,nbnd);
@@ -362,10 +346,6 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   // for (int icol=1; icol<=ncol; icol++) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  // Kokkos::Array<int, 3> dims3_ngpt_nlay_ncol = {ngpt,nlay,ncol};
-  // TIMED_KERNEL(Kokkos::parallel_for( dims3_tot , KOKKOS_LAMBDA (int idx) {
-  //   int igpt, ilay, icol;
-  //   conv::unflatten_idx(idx, dims3_ngpt_nlay_ncol, igpt, ilay, icol);
   TIMED_KERNEL(FLATTEN_MD_KERNEL3(ngpt,nlay,ncol, igpt, ilay, icol,
     lay_src(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay,icol);
   ));
@@ -378,9 +358,6 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
 
   // for (int icol=1; icol<=ncol; icol++) {
   //   for (int ilay=2; ilay<=nlay+1; ilay++) {
-  // TIMED_KERNEL(Kokkos::parallel_for( dims2_ncol_nlay_tot , KOKKOS_LAMBDA (int idx) {
-  //   int icol, ilay;
-  //   conv::unflatten_idx(idx, dims2_ncol_nlay, icol, ilay);
   TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol,nlay, icol, ilay,
     interpolate1D(tlev(icol,ilay+1), temp_ref_min, totplnk_delta, totplnk, Kokkos::subview(planck_function,Kokkos::ALL,ilay+1,icol),nPlanckTemp,nbnd);
   ));
@@ -457,13 +434,7 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
   // for (int ilay=1; ilay<=nlay; ilay++) {
   //   for (int icol=1; icol<=ncol; icol++) {
   //     for (int igpt0=0; igpt0<=max_gpt_diff; igpt0++) {
-  // The CUDA optimizations below perform a lot better than the original
-  // code but yield non-deterministic results.
-// #ifdef KOKKOS_ENABLE_CUDA
-//   TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,extent}) , KOKKOS_LAMBDA (int icol, int ilay, int imnr) {
-// #else
   TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol,nlay, icol, ilay,
-//#endif
     // This check skips individual columns with no pressures in range
     if ( layer_limits(icol,0) <= -1 || ilay < layer_limits(icol,0) || ilay > layer_limits(icol,1) ) {
     } else {

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -255,7 +255,7 @@ void combine_and_reorder_2str(int ncol, int nlay, int ngpt, TauAbsT const &tau_a
   //     for (int tgpt=1; tgpt<=gptTiles; tgpt++) {
   //       for (int itcol=1; itcol<=TILE_SIZE; itcol++) {
   //         for (int itgpt=1; itgpt<=TILE_SIZE; itgpt++) {
-  TIMED_KERNEL(FLATTEN_MD_KERNEL3(ncol,nlay,ngpt, icol, ilay, igpt,
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     RealT t = tau_abs(igpt,ilay,icol) + tau_rayleigh(igpt,ilay,icol);
     tau(icol,ilay,igpt) = t;
     g  (icol,ilay,igpt) = 0.;
@@ -264,7 +264,7 @@ void combine_and_reorder_2str(int ncol, int nlay, int ngpt, TauAbsT const &tau_a
     } else {
       ssa(icol,ilay,igpt) = 0.;
     }
-  ));
+  }));
 }
 
 template <typename TlayT, typename TlevT, typename TsfcT, typename FmajorT, typename JetaT, typename TropoT,
@@ -428,13 +428,10 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
 
   int extent = scale_by_complement.extent(0);
 
-  // Kokkos::Array<int, 2> dims2_ncol_nlay = {ncol,nlay};
-  // const int dims2_ncol_nlay_tot = ncol * nlay;
-
   // for (int ilay=1; ilay<=nlay; ilay++) {
   //   for (int icol=1; icol<=ncol; icol++) {
   //     for (int igpt0=0; igpt0<=max_gpt_diff; igpt0++) {
-  TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol,nlay, icol, ilay,
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
     // This check skips individual columns with no pressures in range
     if ( layer_limits(icol,0) <= -1 || ilay < layer_limits(icol,0) || ilay > layer_limits(icol,1) ) {
     } else {
@@ -491,7 +488,7 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
       }
 //#endif
     }
-  ));
+  }));
 }
 
 // compute minor species optical depths

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -401,7 +401,7 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   // for (int icol=1; icol<=ncol; icol+=2) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
     lev_src_dec(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay,  icol  );
     lev_src_inc(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay+1,icol  );
     if (icol < ncol-1) {
@@ -429,7 +429,7 @@ void compute_tau_rayleigh(int ncol, int nlay, int nbnd, int ngpt, int ngas, int 
   // for (int ilay=1; ilay<=nlay; ilay++) {
   //   for (int icol=1; icol<=ncol; icol++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ngpt,ncol,nlay}) , KOKKOS_LAMBDA (int igpt, int icol, int ilay) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,ncol,nlay}) , KOKKOS_LAMBDA (int igpt, int icol, int ilay) {
     int itropo = merge(0,1,tropo(icol,ilay)); // itropo = 0 lower atmosphere; itropo = 1 upper atmosphere
     int iflav = gpoint_flavor(itropo, igpt);
     // Inlining interpolate2D
@@ -469,7 +469,7 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
 // #ifdef KOKKOS_ENABLE_CUDA
 //   TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getlr<3>({ncol,nlay,extent}) , KOKKOS_LAMBDA (int icol, int ilay, int imnr) {
 // #else
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getlr<2>({ncol,nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
 //#endif
     // This check skips individual columns with no pressures in range
     if ( layer_limits(icol,0) <= -1 || ilay < layer_limits(icol,0) || ilay > layer_limits(icol,1) ) {

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -261,7 +261,7 @@ void combine_and_reorder_2str(int ncol, int nlay, int ngpt, TauAbsT const &tau_a
   // TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<5>({nlay,colTiles,gptTiles,TILE_SIZE,TILE_SIZE}) , KOKKOS_LAMBDA (int ilay, int tcol, int tgpt, int itcol, int itgpt) {
   //   int icol = tcol*TILE_SIZE + itcol;
   //   int igpt = tgpt*TILE_SIZE + itgpt;
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     RealT t = tau_abs(igpt,ilay,icol) + tau_rayleigh(igpt,ilay,icol);
     tau(icol,ilay,igpt) = t;
     g  (icol,ilay,igpt) = 0.;
@@ -549,7 +549,7 @@ void gas_optical_depths_major(int ncol, int nlay, int nbnd, int ngpt, int nflav,
   //     // optical depth calculation for major species
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
   Kokkos::Array<int, 3> dims3_ngpt_ncol_nlay = {ngpt,ncol,nlay};
-  const int dims3_tot = ngpt*ncol*nlay;;
+  const int dims3_tot = ngpt*ncol*nlay;
   TIMED_KERNEL(Kokkos::parallel_for(dims3_tot, KOKKOS_LAMBDA (int idx) {
     int igpt, icol, ilay;
     conv::unflatten_idx_left(idx, dims3_ngpt_ncol_nlay, igpt, icol, ilay);

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -208,7 +208,7 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
     tropo(icol,ilay) = log(play(icol,ilay)) > press_ref_trop_log;
   }));
 
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<4>({2,nflav,ncol,nlay}) , KOKKOS_LAMBDA (int itemp, int iflav, int icol , int ilay) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<4>({2,nflav,ncol,nlay}) , KOKKOS_LAMBDA (int itemp, int iflav, int icol , int ilay) {
     // itropo = 0 lower atmosphere; itropo = 1 upper atmosphere
     int itropo = merge(0,1,tropo(icol,ilay));
     auto igases1 = flavor(0,iflav);
@@ -261,7 +261,7 @@ void combine_and_reorder_2str(int ncol, int nlay, int ngpt, TauAbsT const &tau_a
   // TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<5>({nlay,colTiles,gptTiles,TILE_SIZE,TILE_SIZE}) , KOKKOS_LAMBDA (int ilay, int tcol, int tgpt, int itcol, int itgpt) {
   //   int icol = tcol*TILE_SIZE + itcol;
   //   int igpt = tgpt*TILE_SIZE + itgpt;
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     RealT t = tau_abs(igpt,ilay,icol) + tau_rayleigh(igpt,ilay,icol);
     tau(icol,ilay,igpt) = t;
     g  (icol,ilay,igpt) = 0.;
@@ -467,7 +467,7 @@ void gas_optical_depths_minor(int max_gpt_diff, int ncol, int nlay, int ngpt, in
   // The CUDA optimizations below perform a lot better than the original
   // code but yield non-deterministic results.
 // #ifdef KOKKOS_ENABLE_CUDA
-//   TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getlr<3>({ncol,nlay,extent}) , KOKKOS_LAMBDA (int icol, int ilay, int imnr) {
+//   TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,extent}) , KOKKOS_LAMBDA (int icol, int ilay, int imnr) {
 // #else
   TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
 //#endif

--- a/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_gas_optics_kernels.h
@@ -208,7 +208,7 @@ void interpolation(int ncol, int nlay, int ngas, int nflav, int neta, int npres,
     tropo(icol,ilay) = log(play(icol,ilay)) > press_ref_trop_log;
   }));
 
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<4>({2,nflav,ncol,nlay}) , KOKKOS_LAMBDA (int itemp, int iflav, int icol , int ilay) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<4>({2,nflav,ncol,nlay}) , KOKKOS_LAMBDA (int itemp, int iflav, int icol , int ilay) {
     // itropo = 0 lower atmosphere; itropo = 1 upper atmosphere
     int itropo = merge(0,1,tropo(icol,ilay));
     auto igases1 = flavor(0,iflav);
@@ -401,13 +401,7 @@ void compute_Planck_source(int ncol, int nlay, int nbnd, int ngpt, int nflav, in
   // for (int icol=1; icol<=ncol; icol+=2) {
   //   for (int ilay=1; ilay<=nlay; ilay++) {
   //     for (int igpt=1; igpt<=ngpt; igpt++) {
-#ifdef KOKKOS_ENABLE_CUDA
   TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
-#else
-  TIMED_KERNEL(Kokkos::parallel_for( dims3_tot , KOKKOS_LAMBDA (int idx) {
-    int igpt, ilay, icol;
-    conv::unflatten_idx_left(idx, dims3_ngpt_nlay_ncol, igpt, ilay, icol);
-#endif
     lev_src_dec(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay,  icol  );
     lev_src_inc(igpt,ilay,icol  ) = pfrac(igpt,ilay,icol  ) * planck_function(gpoint_bands(igpt),ilay+1,icol  );
     if (icol < ncol-1) {

--- a/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
@@ -57,7 +57,7 @@ inline void reorder_123x321_kernel(int d1, int d2, int d3, ArrayInT const &array
   //     for (int t1=1; t1<=ntiles1; t1++) {
   //       for (int it3=1; it3<=TILE_SIZE; it3++) {
   //         for (int it1=1; it1<=TILE_SIZE; it1++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getlr<3>({d1,d2,d3}) , KOKKOS_LAMBDA (int i1, int i2, int i3) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({d1,d2,d3}) , KOKKOS_LAMBDA (int i1, int i2, int i3) {
     array_out(i3,i2,i1) = array_in(i1,i2,i3);
   }));
 }

--- a/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
@@ -57,9 +57,9 @@ inline void reorder_123x321_kernel(int d1, int d2, int d3, ArrayInT const &array
   //     for (int t1=1; t1<=ntiles1; t1++) {
   //       for (int it3=1; it3<=TILE_SIZE; it3++) {
   //         for (int it1=1; it1<=TILE_SIZE; it1++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({d1,d2,d3}) , KOKKOS_LAMBDA (int i1, int i2, int i3) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL3(d1,d2,d3, i1, i2, i3,
     array_out(i3,i2,i1) = array_in(i1,i2,i3);
-  }));
+  ));
 }
 
 template <typename ArrayInT, typename ArrayOutT>
@@ -71,8 +71,8 @@ inline void reorder_123x312_kernel(int d1, int d2, int d3, ArrayInT const &array
   // do i3 = 1 , d3
   //   do i2 = 1 , d2
   //     do i1 = 1 , d1
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({d3,d2,d1}) , KOKKOS_LAMBDA (int i3, int i2, int i1) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL3(d3,d2,d1, i3, i2, i1,
     array_out(i3,i1,i2) = array_in(i1,i2,i3);
-  }));
+  ));
 }
 #endif

--- a/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
+++ b/cpp/rrtmgp/kernels/mo_rrtmgp_util_reorder_kernels.h
@@ -57,9 +57,9 @@ inline void reorder_123x321_kernel(int d1, int d2, int d3, ArrayInT const &array
   //     for (int t1=1; t1<=ntiles1; t1++) {
   //       for (int it3=1; it3<=TILE_SIZE; it3++) {
   //         for (int it1=1; it1<=TILE_SIZE; it1++) {
-  TIMED_KERNEL(FLATTEN_MD_KERNEL3(d1,d2,d3, i1, i2, i3,
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({d1,d2,d3}) , KOKKOS_LAMBDA (int i1, int i2, int i3) {
     array_out(i3,i2,i1) = array_in(i1,i2,i3);
-  ));
+  }));
 }
 
 template <typename ArrayInT, typename ArrayOutT>

--- a/cpp/rrtmgp/mo_gas_concentrations.h
+++ b/cpp/rrtmgp/mo_gas_concentrations.h
@@ -286,6 +286,9 @@ public:
     }
   }
 
+  // This function does the same thing as the one above, except takes concs_mem as an argument
+  // instead of allocating it. Presumably, this would come from the pool
+  // allocator in order to avoid cudaMalloc (hurts performance).
   template <typename ConcsMem>
   void init_no_alloc(string1dv const &gas_names , int ncol , int nlay, ConcsMem const& concs_mem) {
     this->reset();

--- a/cpp/rrtmgp/mo_gas_concentrations.h
+++ b/cpp/rrtmgp/mo_gas_concentrations.h
@@ -278,7 +278,7 @@ public:
 
     // Allocate
     this->gas_name = string1dv(ngas);
-    this->concs  = real3d_t("concs"   ,ncol,nlay,ngas);
+    this->concs  = real3d_t("concs"   ,ncol,nlay,ngas); // ALLOC
 
     // Assign gas names
     for (int i=0; i<ngas; i++) {
@@ -286,6 +286,35 @@ public:
     }
   }
 
+  template <typename ConcsMem>
+  void init_no_alloc(string1dv const &gas_names , int ncol , int nlay, ConcsMem const& concs_mem) {
+    this->reset();
+    this->ngas = gas_names.size();
+    this->ncol = ncol;
+    this->nlay = nlay;
+
+    // Transform gas names to lower case, check for empty strings, check for duplicates
+    for (int i=0; i<ngas; i++) {
+      // Empty string
+      if (gas_names[i] == "") { stoprun("ERROR: GasConcs::init(): must provide non-empty gas names"); }
+      // Duplicate gas name
+      for (int j=i+1; j<ngas; j++) {
+        if ( lower_case(gas_names[i]) == lower_case(gas_names[j]) ) { stoprun("GasConcs::init(): duplicate gas names aren't allowed"); }
+      }
+    }
+
+    // Allocate
+    this->gas_name = string1dv(ngas);
+    this->concs    = concs_mem;
+    assert(concs_mem.extent(0) == ncol);
+    assert(concs_mem.extent(1) == nlay);
+    assert(concs_mem.extent(2) == this->ngas);
+
+    // Assign gas names
+    for (int i=0; i<ngas; i++) {
+      this->gas_name[i] = lower_case(gas_names[i]);
+    }
+  }
 
   // Set concentration as a scalar copied to every column and level
   void set_vmr(std::string gas, const RealT w) {

--- a/cpp/rrtmgp/mo_gas_concentrations.h
+++ b/cpp/rrtmgp/mo_gas_concentrations.h
@@ -324,17 +324,17 @@ public:
     }
     if (w < 0. || w > 1.) { stoprun("GasConcs::set_vmr(): concentrations should be >= 0, <= 1"); }
     auto this_concs = this->concs;
-    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({ncol, nlay}), KOKKOS_LAMBDA(int icol, int ilay) {
+    TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlay, icol, ilay,
       this_concs(icol, ilay, igas) = w;
-    }));
+    ));
   }
 
   template <typename ViewT>
   static void inline set_concs_impl(ViewT const &w, const int nlay, const int ncol, const int igas, const real3d_t& concs)
   {
-    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({ncol, nlay}), KOKKOS_LAMBDA(int icol, int ilay) {
+    TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlay, icol, ilay,
       concs(icol, ilay, igas) = w(ilay);
-    }));
+    ));
   }
 
   // Set concentration as a single column copied to all other columns
@@ -361,9 +361,9 @@ public:
   template <typename ViewT>
   static void inline set_concs_impl2(ViewT const &w, const int nlay, const int ncol, const int igas, const real3d_t& concs)
   {
-    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({ncol, nlay}), KOKKOS_LAMBDA(int icol, int ilay) {
+    TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlay, icol, ilay,
       concs(icol, ilay, igas) = w(icol, ilay);
-    }));
+    ));
   }
 
   // Set concentration as a 2-D field of columns and levels
@@ -400,9 +400,9 @@ public:
     // for (int ilay=1; ilay<=size(array,2); ilay++) {
     //   for (int icol=1; icol<=size(array,1); icol++) {
     auto this_concs = this->concs;
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({array.extent(0), array.extent(1)}) , KOKKOS_LAMBDA (int icol, int ilay) {
+    TIMED_KERNEL(FLATTEN_MD_KERNEL2(array.extent(0), array.extent(1), icol, ilay,
       array(icol,ilay) = this_concs(icol,ilay,igas);
-    }));
+    ));
   }
 
   int get_num_gases() const { return gas_name.size(); }

--- a/cpp/rrtmgp/mo_gas_concentrations.h
+++ b/cpp/rrtmgp/mo_gas_concentrations.h
@@ -295,7 +295,7 @@ public:
     }
     if (w < 0. || w > 1.) { stoprun("GasConcs::set_vmr(): concentrations should be >= 0, <= 1"); }
     auto this_concs = this->concs;
-    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA(int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({ncol, nlay}), KOKKOS_LAMBDA(int icol, int ilay) {
       this_concs(icol, ilay, igas) = w;
     }));
   }
@@ -303,7 +303,7 @@ public:
   template <typename ViewT>
   static void inline set_concs_impl(ViewT const &w, const int nlay, const int ncol, const int igas, const real3d_t& concs)
   {
-    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA(int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({ncol, nlay}), KOKKOS_LAMBDA(int icol, int ilay) {
       concs(icol, ilay, igas) = w(ilay);
     }));
   }
@@ -332,7 +332,7 @@ public:
   template <typename ViewT>
   static void inline set_concs_impl2(ViewT const &w, const int nlay, const int ncol, const int igas, const real3d_t& concs)
   {
-    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({nlay,ncol}), KOKKOS_LAMBDA(int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for(mdrp_t::template get<2>({ncol, nlay}), KOKKOS_LAMBDA(int icol, int ilay) {
       concs(icol, ilay, igas) = w(icol, ilay);
     }));
   }
@@ -371,7 +371,7 @@ public:
     // for (int ilay=1; ilay<=size(array,2); ilay++) {
     //   for (int icol=1; icol<=size(array,1); icol++) {
     auto this_concs = this->concs;
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({array.extent(1),array.extent(0)}) , KOKKOS_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({array.extent(0), array.extent(1)}) , KOKKOS_LAMBDA (int icol, int ilay) {
       array(icol,ilay) = this_concs(icol,ilay,igas);
     }));
   }

--- a/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
+++ b/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
@@ -2072,7 +2072,7 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     if (toa_src.extent(0) != ncol || toa_src.extent(1) != ngpt) { stoprun("gas_optics(): array toa_src has wrong size"); }
 
     auto this_solar_src = this->solar_src;
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       toa_src(icol,igpt) = this_solar_src(igpt);
     }));
 
@@ -2176,13 +2176,13 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // compute column gas amounts [molec/cm^2]
     // do ilay = 1, nlay
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlay,ncol}) , KOKKOS_LAMBDA (int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
       col_gas(icol,ilay,0) = col_dry_wk(icol,ilay);
     }));
     // do igas = 1, ngas
     //   do ilay = 1, nlay
     //     do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngas,nlay,ncol}) , KOKKOS_LAMBDA (int igas, int ilay, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol, nlay, ngas}) , KOKKOS_LAMBDA (int icol, int ilay, int igas) {
       col_gas(icol,ilay,igas+1) = vmr(icol,ilay,igas) * col_dry_wk(icol,ilay);
     }));
     // ---- calculate gas optical depths ----
@@ -2244,7 +2244,7 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
       //   Interpolation and extrapolation at boundaries is weighted by pressure
       // do ilay = 1, nlay+1
       //   do icol = 1, ncol
-      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlay+1,ncol}) , KOKKOS_LAMBDA (int ilay, int icol) {
+      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlay+1}) , KOKKOS_LAMBDA (int icol, int ilay) {
         if (ilay == 0) {
           tlev_wk(icol,0) = tlay(icol,0) + (plev(icol,0)-play(icol,0))*(tlay(icol,1)-tlay(icol,0)) / (play(icol,1)-play(icol,0));
         }
@@ -2271,7 +2271,7 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     auto &sources_sfc_source = sources.sfc_source;
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       sources_sfc_source(icol,igpt) = sfc_source_t(igpt,icol);
     }));
     reorder123x321(ngpt, nlay, ncol, lay_source_t    , sources.lay_source    );
@@ -2309,7 +2309,7 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     const auto m_dry = const_t::m_dry;
     const auto m_h2o = const_t::m_h2o;
     const auto avogad = const_t::avogad;
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlev-1,ncol}) , KOKKOS_LAMBDA (int ilev , int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlev-1}) , KOKKOS_LAMBDA (int icol, int ilev) {
       RealT delta_plev = Kokkos::fabs(plev(icol,ilev) - plev(icol,ilev+1));
       // Get average mass of moist air per mole of moist air
       RealT fact = 1. / (1.+vmr_h2o(icol,ilev));

--- a/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
+++ b/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
@@ -970,8 +970,6 @@ public:
       #endif
     }
 
-    bool use_rayl = allocated(this->krayl);
-
     int ngas  = this->get_ngas();
     int nflav = this->get_nflav();
     int neta  = this->get_neta();
@@ -2053,17 +2051,16 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
                   bool top_at_1, PlayT const &play, PlevT const &plev, TlayT const &tlay,
                   GasConcsK<RealT, LayoutT, DeviceT> const &gas_desc,
                   ColGasT const& col_gas, OpticalPropsT &optical_props, ToaT &toa_src, ColDryT const &col_dry=ColDryT()) {
-    int ngpt  = this->get_ngpt();
-    int nband = this->get_nband();
-    int ngas  = this->get_ngas();
-    int nflav = get_nflav();
+    const int ngpt  = this->get_ngpt();
+    const int nband = this->get_nband();
+    const int nflav = get_nflav();
 
     // Interpolation coefficients for use in source function
     auto jtemp  = pool_t::template alloc<int>(ncol,nlay);
     auto jpress = pool_t::template alloc<int>(ncol,nlay);
     auto tropo  = pool_t::template alloc<bool>(ncol,nlay);
-    auto fmajor = pool_t::template alloc<RealT>(2,2,2,this->get_nflav(),ncol,nlay);
-    auto jeta   = pool_t::template alloc<int>(2,this->get_nflav(),ncol,nlay);
+    auto fmajor = pool_t::template alloc<RealT>(2,2,2,nflav,ncol,nlay);
+    auto jeta   = pool_t::template alloc<int>(2,nflav,ncol,nlay);
     // Gas optics
     compute_gas_taus(top_at_1, ncol, nlay, ngpt, nband, play, plev, tlay, gas_desc, col_gas, optical_props, jtemp, jpress, jeta,
                      tropo, fmajor, col_dry);
@@ -2095,28 +2092,21 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
                         TropoT const &tropo, FmajorT const &fmajor, ColDryT const &col_dry=ColDryT() ) {
     // Number of molecules per cm^2
     const int nlev = plev.extent(1);
-    const int size1 = ngpt*nlay*ncol;
-    const int size2 = ncol*nlay*this->get_ngas();
-    const int size3 = 2*this->get_nflav()*ncol*nlay;
-    const int size4 = 2*2*this->get_nflav()*ncol*nlay;
-    const int size5 = ncol;
-    const int size6 = ncol * (nlev-1);
-    RealT* data = pool_t::template alloc_raw<RealT>(size1*2 + size2 + size3 + size4 + size5 + size6), *dcurr = data;
-    uview_t<RealT***> tau         (dcurr,ngpt,nlay,ncol); dcurr += size1;
-    uview_t<RealT***> tau_rayleigh(dcurr,ngpt,nlay,ncol); dcurr += size1;
+    auto tau         = pool_t::template alloc<RealT>(ngpt,nlay,ncol);
+    auto tau_rayleigh= pool_t::template alloc<RealT>(ngpt,nlay,ncol);
     // Interpolation variables used in major gas but not elsewhere, so don't need exporting
-    uview_t<RealT***> vmr         (dcurr,ncol,nlay,this->get_ngas()); dcurr += size2;
-    uview_t<RealT****> col_mix     (dcurr,2,this->get_nflav(),ncol,nlay); dcurr += size3; // combination of major species's column amounts
+    auto vmr         = pool_t::template alloc<RealT>(ncol,nlay,this->get_ngas());
+    auto col_mix     = pool_t::template alloc<RealT>(2,this->get_nflav(),ncol,nlay); // combination of major species's column amounts
                                                                                // index(1) : reference temperature level
                                                                                // index(2) : flavor
                                                                                // index(3) : layer
-    uview_t<RealT*****> fminor      (dcurr,2,2,this->get_nflav(),ncol,nlay); dcurr += size4; // interpolation fractions for minor species
+    auto fminor      = pool_t::template alloc<RealT>(2,2,this->get_nflav(),ncol,nlay); // interpolation fractions for minor species
                                                                                  // index(1) : reference eta level (temperature dependent)
                                                                                  // index(2) : reference temperature level
                                                                                  // index(3) : flavor
                                                                                  // index(4) : layer
-    uview_t<RealT*> g0(dcurr, ncol); dcurr += size5;
-    uview_t<RealT**> col_dry_tmp(dcurr, ncol, nlev-1); dcurr += size6;
+    auto g0 = pool_t::template alloc<RealT>( ncol);
+    auto col_dry_tmp= pool_t::template alloc<RealT>( ncol, nlev-1);
 
     // Error checking
     // Check for initialization
@@ -2140,8 +2130,6 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
         if (any(col_dry < 0.)) { stoprun("gas_optics(): array col_dry has values outside range"); }
       #endif
     }
-
-    bool use_rayl = this->krayl.is_allocated();
 
     int ngas  = this->get_ngas();
     int nflav = this->get_nflav();
@@ -2209,7 +2197,13 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     }
     combine_and_reorder(tau, tau_rayleigh, this->krayl.is_allocated(), optical_props);
 
-    pool_t::dealloc(data, dcurr - data);
+    pool_t::dealloc(tau);
+    pool_t::dealloc(tau_rayleigh);
+    pool_t::dealloc(vmr);
+    pool_t::dealloc(col_mix);
+    pool_t::dealloc(fminor);
+    pool_t::dealloc(g0);
+    pool_t::dealloc(col_dry_tmp);
   }
 
   // Compute Planck source functions at layer centers and levels
@@ -2221,25 +2215,21 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
               TsfcT const &tsfc, JtempT const &jtemp, JpressT const &jpress, JetaT const &jeta,
               TropoT const &tropo, FmajorT const &fmajor, SourceFuncLWK<RealT, LayoutT, DeviceT> &sources,
               TlevT const &tlev=TlevT()) {
-    const int dsize1 = ngpt * nlay * ncol;
-    const int dsize2 = ngpt * ncol;
-    const int dsize3 = ncol * (nlay+1);
-    RealT* data = pool_t::template alloc_raw<RealT>(dsize1*3 + dsize2 + dsize3*2), *dcurr = data;
-    uview_t<RealT***> lay_source_t    (dcurr,ngpt,nlay,ncol); dcurr += dsize1;
-    uview_t<RealT***> lev_source_inc_t(dcurr,ngpt,nlay,ncol); dcurr += dsize1;
-    uview_t<RealT***> lev_source_dec_t(dcurr,ngpt,nlay,ncol); dcurr += dsize1;
-    uview_t<RealT**> sfc_source_t    (dcurr,ngpt     ,ncol); dcurr += dsize2;
+    auto lay_source_t     = pool_t::template alloc<RealT>(ngpt,nlay,ncol);
+    auto lev_source_inc_t = pool_t::template alloc<RealT>(ngpt,nlay,ncol);
+    auto lev_source_dec_t = pool_t::template alloc<RealT>(ngpt,nlay,ncol);
+    auto sfc_source_t     = pool_t::template alloc<RealT>(ngpt     ,ncol);
     // Variables for temperature at layer edges [K] (ncol, nlay+1)
-    uview_t<RealT**> tlev_arr(dcurr,ncol,nlay+1); dcurr += dsize3;
+    auto tlev_arr         = pool_t::template alloc<RealT>(ncol,nlay+1);
 
     // Source function needs temperature at interfaces/levels and at layer centers
+    auto tlev_wk_pool = pool_t::template alloc<RealT>(ncol,nlay+1);
     uview_t<RealT**> tlev_wk;
     if (tlev.is_allocated()) {
       //   Users might have provided these
       tlev_wk = tlev;
-      dcurr += dsize3;
     } else {
-      tlev_wk = view_t<RealT**>(dcurr,ncol,nlay+1); dcurr += dsize3;
+      tlev_wk = tlev_wk_pool;
       // Interpolate temperature to levels if not provided
       //   Interpolation and extrapolation at boundaries is weighted by pressure
       // do ilay = 1, nlay+1
@@ -2278,7 +2268,12 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     reorder123x321(ngpt, nlay, ncol, lev_source_inc_t, sources.lev_source_inc);
     reorder123x321(ngpt, nlay, ncol, lev_source_dec_t, sources.lev_source_dec);
 
-    pool_t::dealloc(data, dcurr - data);
+    pool_t::dealloc(lay_source_t);
+    pool_t::dealloc(lev_source_inc_t);
+    pool_t::dealloc(lev_source_dec_t);
+    pool_t::dealloc(sfc_source_t);
+    pool_t::dealloc(tlev_arr);
+    pool_t::dealloc(tlev_wk_pool);
   }
 
   // Utility function, provided for user convenience

--- a/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
+++ b/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
@@ -1243,7 +1243,7 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
 
   using parent_t = OpticalPropsK<RealT, LayoutT, DeviceT>;
   using hparent_t = OpticalPropsK<RealT, LayoutT, HostDevice>;
-  using pool_t = conv::MemPoolSingleton<RealT, DeviceT>;
+  using pool_t = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
   using const_t = rrtmgp_constants<RealT>;
   using mdrp_t = typename conv::MDRP<LayoutT, DeviceT>;
 

--- a/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
+++ b/cpp/rrtmgp/mo_gas_optics_rrtmgp.h
@@ -1807,9 +1807,9 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     //   do i = 1, size(this%flavor, 1) ! extents should be 2
     auto this_flavor = this->flavor;
     auto this_is_key = this->is_key;
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({this->flavor.extent(0), this->flavor.extent(1)}) , KOKKOS_LAMBDA (int i, int j) {
+    TIMED_KERNEL(FLATTEN_MD_KERNEL2(this->flavor.extent(0), this->flavor.extent(1), i, j,
       if (this_flavor(i,j) != -1) { this_is_key(this_flavor(i,j)) = true; }
-    }));
+    ));
   }
 
   // Initialize object based on data read from netCDF file however the user desires.
@@ -2069,9 +2069,9 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     if (toa_src.extent(0) != ncol || toa_src.extent(1) != ngpt) { stoprun("gas_optics(): array toa_src has wrong size"); }
 
     auto this_solar_src = this->solar_src;
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
+    TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, ngpt, icol, igpt,
       toa_src(icol,igpt) = this_solar_src(igpt);
-    }));
+    ));
 
     pool_t::dealloc(jtemp);
     pool_t::dealloc(jpress);
@@ -2164,15 +2164,15 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     // compute column gas amounts [molec/cm^2]
     // do ilay = 1, nlay
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlay}) , KOKKOS_LAMBDA (int icol, int ilay) {
+    TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlay, icol, ilay,
       col_gas(icol,ilay,0) = col_dry_wk(icol,ilay);
-    }));
+    ));
     // do igas = 1, ngas
     //   do ilay = 1, nlay
     //     do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol, nlay, ngas}) , KOKKOS_LAMBDA (int icol, int ilay, int igas) {
+    TIMED_KERNEL(FLATTEN_MD_KERNEL3(ncol, nlay, ngas, icol, ilay, igas,
       col_gas(icol,ilay,igas+1) = vmr(icol,ilay,igas) * col_dry_wk(icol,ilay);
-    }));
+    ));
     // ---- calculate gas optical depths ----
     Kokkos::deep_copy(tau, 0);
 
@@ -2234,7 +2234,7 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
       //   Interpolation and extrapolation at boundaries is weighted by pressure
       // do ilay = 1, nlay+1
       //   do icol = 1, ncol
-      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlay+1}) , KOKKOS_LAMBDA (int icol, int ilay) {
+      TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlay+1, icol, ilay,
         if (ilay == 0) {
           tlev_wk(icol,0) = tlay(icol,0) + (plev(icol,0)-play(icol,0))*(tlay(icol,1)-tlay(icol,0)) / (play(icol,1)-play(icol,0));
         }
@@ -2247,7 +2247,7 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
                                  play(icol,ilay  )*tlay(icol,ilay  )*(play(icol,ilay-1)-plev(icol,ilay)) ) /
             (plev(icol,ilay)*(play(icol,ilay-1) - play(icol,ilay)));
         }
-      }));
+      ));
     }
     // Compute internal (Planck) source functions at layers and levels,
     //  which depend on mapping from spectral space that creates k-distribution.
@@ -2261,9 +2261,9 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     auto &sources_sfc_source = sources.sfc_source;
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
+    TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, ngpt, icol, igpt,
       sources_sfc_source(icol,igpt) = sfc_source_t(igpt,icol);
-    }));
+    ));
     reorder123x321(ngpt, nlay, ncol, lay_source_t    , sources.lay_source    );
     reorder123x321(ngpt, nlay, ncol, lev_source_inc_t, sources.lev_source_inc);
     reorder123x321(ngpt, nlay, ncol, lev_source_dec_t, sources.lev_source_dec);
@@ -2304,13 +2304,13 @@ class GasOpticsRRTMGPK : public OpticalPropsK<RealT, LayoutT, DeviceT> {
     const auto m_dry = const_t::m_dry;
     const auto m_h2o = const_t::m_h2o;
     const auto avogad = const_t::avogad;
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlev-1}) , KOKKOS_LAMBDA (int icol, int ilev) {
+    TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlev-1, icol, ilev,
       RealT delta_plev = Kokkos::fabs(plev(icol,ilev) - plev(icol,ilev+1));
       // Get average mass of moist air per mole of moist air
       RealT fact = 1. / (1.+vmr_h2o(icol,ilev));
       RealT m_air = (m_dry + m_h2o * vmr_h2o(icol,ilev)) * fact;
       col_dry(icol,ilev) = 10. * delta_plev * avogad * fact/(1000.*m_air*100.*g0(icol));
-    }));
+    ));
   }
 
   // Utility function to combine optical depths from gas absorption and Rayleigh scattering

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -622,14 +622,14 @@ sum(const KView& view)
 }
 
 // MemPool singleton. Stack allocation pattern only.
-template <typename RealT, typename DeviceT>
+template <typename RealT, typename LayoutT, typename DeviceT>
 struct MemPoolSingleton
 {
  public:
-  using memview_t = Kokkos::View<RealT*, Kokkos::LayoutRight, DeviceT>;
+  using memview_t = Kokkos::View<RealT*, LayoutT, DeviceT>;
 
   template <typename T>
-  using view_t = Kokkos::View<T, Kokkos::LayoutRight, DeviceT>;
+  using view_t = Kokkos::View<T, LayoutT, DeviceT>;
 
   static inline memview_t  s_mem;
   static inline int64_t s_curr_used;

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -414,7 +414,16 @@ void unflatten_idx_left(const int idx, const Kokkos::Array<int, 3>& dims, int& i
 {
   i = idx % dims[0];
   j = (idx / dims[0]) % dims[1];
-  k = (idx / dims[0]) / dims[1];
+  k = idx / (dims[0] * dims[1]);
+}
+
+KOKKOS_INLINE_FUNCTION
+void unflatten_idx_rev(const int idx, const Kokkos::Array<int, 4>& dims, int& i, int& j, int& k, int& l)
+{
+  i = idx % dims[0];
+  j = (idx / dims[0]) % dims[1];
+  k = (idx / (dims[0]*dims[1])) % dims[2];
+  l = idx / (dims[0]*dims[1]*dims[2]);
 }
 
 KOKKOS_INLINE_FUNCTION
@@ -427,11 +436,19 @@ void unflatten_idx_right(const int idx, const Kokkos::Array<int, 2>& dims, int& 
 KOKKOS_INLINE_FUNCTION
 void unflatten_idx_right(const int idx, const Kokkos::Array<int, 3>& dims, int& i, int& j, int& k)
 {
-  i = (idx / dims[2]) / dims[1];
+  i = idx / (dims[2] * dims[1]);
   j = (idx / dims[2]) % dims[1];
   k =  idx % dims[2];
 }
 
+KOKKOS_INLINE_FUNCTION
+void unflatten_idx_right(const int idx, const Kokkos::Array<int, 4>& dims, int& i, int& j, int& k, int& l)
+{
+  i = idx / (dims[3]*dims[2]*dims[1]);
+  j = (idx / (dims[3]*dims[2])) % dims[1];
+  k = (idx / dims[3]) % dims[2];
+  l = idx % dims[3];
+}
 
 #ifdef RRTMGP_ENABLE_YAKL
 // Compare a yakl array to a kokkos view, checking they are functionally

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -27,7 +27,7 @@
 #define KERNEL_FENCE yakl::fence()
 #endif
 
-#define ENABLE_TIMING
+// #define ENABLE_TIMING
 // Macro for timing kernels
 #ifdef ENABLE_TIMING
 #define TIMED_KERNEL(kernel)                                            \

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -61,7 +61,7 @@
   total_s##name += duration##name.count() / 1000000.0;                  \
   std::cout << "TIMING For func " << __func__ << " file " << __FILE__ << " line " << __LINE__ << " total " << total_s##name << " s" << std::endl
 #else
-#define TIMED_KERNEL(kernel) kernel
+#define TIMED_INLINE_KERNEL(kernel) kernel
 #endif
 
 

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -46,6 +46,25 @@
 #define TIMED_KERNEL(kernel) kernel
 #endif
 
+// Macro for timing kernels that does not make a code block. Requires
+// a name to disambiguate variable names. Useful when code block defines
+// variables that need to persist.
+#ifdef ENABLE_TIMING
+#define TIMED_INLINE_KERNEL(name, kernel)                               \
+  KERNEL_FENCE;                                                         \
+  auto start_t##name = std::chrono::high_resolution_clock::now();       \
+  kernel;                                                               \
+  KERNEL_FENCE;                                                         \
+  auto stop_t##name = std::chrono::high_resolution_clock::now();        \
+  auto duration##name = std::chrono::duration_cast<std::chrono::microseconds>(stop_t##name - start_t##name); \
+  static double total_s##name = 0.;                                     \
+  total_s##name += duration##name.count() / 1000000.0;                  \
+  std::cout << "TIMING For func " << __func__ << " file " << __FILE__ << " line " << __LINE__ << " total " << total_s##name << " s" << std::endl
+#else
+#define TIMED_KERNEL(kernel) kernel
+#endif
+
+
 /**
  * Helper functions for the conversion to Kokkos
  */

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -359,30 +359,26 @@ template <> struct DefaultTile<5> {
 template <typename LayoutT, typename DeviceT=DefaultDevice>
 struct MDRP
 {
-  // static constexpr Kokkos::Iterate LeftI = std::is_same_v<LayoutT, Kokkos::LayoutRight>
-  //   ? Kokkos::Iterate::Left
-  //   : Kokkos::Iterate::Right;
-  // static constexpr Kokkos::Iterate RightI = std::is_same_v<LayoutT, Kokkos::LayoutRight>
-  //   ? Kokkos::Iterate::Right
-  //   : Kokkos::Iterate::Left;
-#ifdef KOKKOS_ENABLE_CUDA
-  static constexpr Kokkos::Iterate LeftI = Kokkos::Iterate::Left;
-  static constexpr Kokkos::Iterate RightI = Kokkos::Iterate::Right;
-#else
-  static constexpr Kokkos::Iterate LeftI = Kokkos::Iterate::Default;
-  static constexpr Kokkos::Iterate RightI = Kokkos::Iterate::Default;
-#endif
+  // By default, follow the Layout's fast index
+  static constexpr Kokkos::Iterate LeftI = std::is_same_v<LayoutT, Kokkos::LayoutRight>
+    ? Kokkos::Iterate::Left
+    : Kokkos::Iterate::Right;
+  static constexpr Kokkos::Iterate RightI = std::is_same_v<LayoutT, Kokkos::LayoutRight>
+    ? Kokkos::Iterate::Right
+    : Kokkos::Iterate::Left;
 
   using exe_space_t = typename DeviceT::execution_space;
 
   template <int Rank>
   using MDRP_t = Kokkos::MDRangePolicy<exe_space_t, Kokkos::Rank<Rank, LeftI, RightI> >;
 
+  // Force a right to left (right fast index) loop order
   template <int Rank>
-  using MDRPLR_t = Kokkos::MDRangePolicy<exe_space_t, Kokkos::Rank<Rank, Kokkos::Iterate::Left, Kokkos::Iterate::Right> >;
+  using MDRPRL_t = Kokkos::MDRangePolicy<exe_space_t, Kokkos::Rank<Rank, Kokkos::Iterate::Left, Kokkos::Iterate::Right> >;
 
+  // Force a left to right (left fast index) loop order
   template <int Rank>
-  using MDRPRL_t = Kokkos::MDRangePolicy<exe_space_t, Kokkos::Rank<Rank, Kokkos::Iterate::Right, Kokkos::Iterate::Left> >;
+  using MDRPLR_t = Kokkos::MDRangePolicy<exe_space_t, Kokkos::Rank<Rank, Kokkos::Iterate::Right, Kokkos::Iterate::Left> >;
 
   template <int N, typename IntT>
   static inline
@@ -437,7 +433,7 @@ void unflatten_idx_left(const int idx, const Kokkos::Array<int, 3>& dims, int& i
 }
 
 KOKKOS_INLINE_FUNCTION
-void unflatten_idx_rev(const int idx, const Kokkos::Array<int, 4>& dims, int& i, int& j, int& k, int& l)
+void unflatten_idx_left(const int idx, const Kokkos::Array<int, 4>& dims, int& i, int& j, int& k, int& l)
 {
   i = idx % dims[0];
   j = (idx / dims[0]) % dims[1];

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -27,7 +27,7 @@
 #define KERNEL_FENCE yakl::fence()
 #endif
 
-#define ENABLE_TIMING
+//#define ENABLE_TIMING
 // Macro for timing kernels
 #ifdef ENABLE_TIMING
 #define TIMED_KERNEL(kernel)                                            \

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -138,7 +138,7 @@ template <typename YArray,
           typename std::enable_if<!is_view_v<YArray>>::type* = nullptr>
 void p1d(const YArray& array, const std::string& name, int idx)
 {
-  const int adjust_val = std::is_same<typename YArray::non_const_value_type, int>::value ? 1 : 0;
+  const int adjust_val = std::is_same_v<typename YArray::non_const_value_type, int> ? 1 : 0;
   std::cout << "JGFY " << name << "(" << idx-1 << ") = " << array(idx) - adjust_val << std::endl; }
 
 template <typename KView,
@@ -150,7 +150,7 @@ template <typename YArray,
           typename std::enable_if<!is_view_v<YArray>>::type* = nullptr>
 void p2d(const YArray& array, const std::string& name, int idx1, int idx2)
 {
-  const int adjust_val = std::is_same<typename YArray::non_const_value_type, int>::value ? 1 : 0;
+  const int adjust_val = std::is_same_v<typename YArray::non_const_value_type, int> ? 1 : 0;
   std::cout << "JGFY " << name << "(" << idx1-1 << ", " << idx2-1 << ") = " << array(idx1, idx2) - adjust_val << std::endl; }
 
 template <typename KView,
@@ -162,7 +162,7 @@ template <typename YArray,
           typename std::enable_if<!is_view_v<YArray>>::type* = nullptr>
 void p3d(const YArray& array, const std::string& name, int idx1, int idx2, int idx3)
 {
-  const int adjust_val = std::is_same<typename YArray::non_const_value_type, int>::value ? 1 : 0;
+  const int adjust_val = std::is_same_v<typename YArray::non_const_value_type, int> ? 1 : 0;
   std::cout << "JGFY " << name << "(" << idx1-1 << ", " << idx2-1 << ", " << idx3-1 << ") = " << array(idx1, idx2, idx3) - adjust_val << std::endl;
 }
 
@@ -175,7 +175,7 @@ template <typename YArray,
           typename std::enable_if<!is_view_v<YArray>>::type* = nullptr>
 void p4d(const YArray& array, const std::string& name, int idx1, int idx2, int idx3, int idx4)
 {
-  const int adjust_val = std::is_same<typename YArray::non_const_value_type, int>::value ? 1 : 0;
+  const int adjust_val = std::is_same_v<typename YArray::non_const_value_type, int> ? 1 : 0;
   std::cout << "JGFY " << name << "(" << idx1-1 << ", " << idx2-1 << ", " << idx3-1 << ", " << idx4-1 << ") = " << array(idx1, idx2, idx3, idx4) - adjust_val << std::endl;
 }
 
@@ -188,7 +188,7 @@ template <typename YArray,
           typename std::enable_if<!is_view_v<YArray>>::type* = nullptr>
 void p5d(const YArray& array, const std::string& name, int idx1, int idx2, int idx3, int idx4, int idx5)
 {
-  const int adjust_val = std::is_same<typename YArray::non_const_value_type, int>::value ? 1 : 0;
+  const int adjust_val = std::is_same_v<typename YArray::non_const_value_type, int> ? 1 : 0;
   std::cout << "JGFY " << name << "(" << idx1-1 << ", " << idx2-1 << ", " << idx3-1 << ", " << idx4-1 << ", " << idx5-1 << ") = " << array(idx1, idx2, idx3, idx4, idx5) - adjust_val << std::endl;
 }
 
@@ -201,7 +201,7 @@ template <typename YArray,
           typename std::enable_if<!is_view_v<YArray>>::type* = nullptr>
 void p6d(const YArray& array, const std::string& name, int idx1, int idx2, int idx3, int idx4, int idx5, int idx6)
 {
-  const int adjust_val = std::is_same<typename YArray::non_const_value_type, int>::value ? 1 : 0;
+  const int adjust_val = std::is_same_v<typename YArray::non_const_value_type, int> ? 1 : 0;
   std::cout << "JGFY " << name << "(" << idx1-1 << ", " << idx2-1 << ", " << idx3-1 << ", " << idx4-1 << ", " << idx5-1 << ", " << idx6-1 << ") = " << array(idx1, idx2, idx3, idx4, idx5, idx6) - adjust_val << std::endl;
 }
 
@@ -465,13 +465,49 @@ void unflatten_idx_right(const int idx, const Kokkos::Array<int, 4>& dims, int& 
   l = idx % dims[3];
 }
 
+template <typename LayoutT>
+KOKKOS_INLINE_FUNCTION
+void unflatten_idx(const int idx, const Kokkos::Array<int, 2>& dims, int& i, int& j)
+{
+  if constexpr (std::is_same_v<LayoutT, Kokkos::LayoutLeft>) {
+    unflatten_idx_left(idx, dims, i, j);
+  }
+  else {
+    unflatten_idx_right(idx, dims, i, j);
+  }
+}
+
+template <typename LayoutT>
+KOKKOS_INLINE_FUNCTION
+void unflatten_idx(const int idx, const Kokkos::Array<int, 3>& dims, int& i, int& j, int& k)
+{
+  if constexpr (std::is_same_v<LayoutT, Kokkos::LayoutLeft>) {
+    unflatten_idx_left(idx, dims, i, j, k);
+  }
+  else {
+    unflatten_idx_right(idx, dims, i, j, k);
+  }
+}
+
+template <typename LayoutT>
+KOKKOS_INLINE_FUNCTION
+void unflatten_idx(const int idx, const Kokkos::Array<int, 4>& dims, int& i, int& j, int& k, int& l)
+{
+  if constexpr (std::is_same_v<LayoutT, Kokkos::LayoutLeft>) {
+    unflatten_idx_left(idx, dims, i, j, k, l);
+  }
+  else {
+    unflatten_idx_right(idx, dims, i, j, k, l);
+  }
+}
+
 #define FLATTEN_MD_KERNEL2(n1, n2, i1, i2, kernel)     \
   {                                                     \
     Kokkos::Array<int, 2> dims_fmk_internal = {n1, n2};         \
     const int dims_fmk_internal_tot = (n1)*(n2);                        \
     Kokkos::parallel_for(dims_fmk_internal_tot, KOKKOS_LAMBDA (int idx_fmk_internal) { \
       int i1, i2;                                                     \
-      conv::unflatten_idx_left(idx_fmk_internal, dims_fmk_internal, i1, i2); \
+      conv::unflatten_idx<LayoutT>(idx_fmk_internal, dims_fmk_internal, i1, i2); \
       kernel;                                                           \
     });                                                               \
   }
@@ -482,7 +518,7 @@ void unflatten_idx_right(const int idx, const Kokkos::Array<int, 4>& dims, int& 
     const int dims_fmk_internal_tot = (n1)*(n2)*(n3);                   \
     Kokkos::parallel_for(dims_fmk_internal_tot, KOKKOS_LAMBDA (int idx_fmk_internal) { \
       int i1, i2, i3;                                                 \
-      conv::unflatten_idx_left(idx_fmk_internal, dims_fmk_internal, i1, i2, i3); \
+      conv::unflatten_idx<LayoutT>(idx_fmk_internal, dims_fmk_internal, i1, i2, i3); \
       kernel;                                                           \
     });                                                               \
   }
@@ -493,7 +529,7 @@ void unflatten_idx_right(const int idx, const Kokkos::Array<int, 4>& dims, int& 
     const int dims_fmk_internal_tot = (n1)*(n2)*(n3)*(n4);              \
     Kokkos::parallel_for(dims_fmk_internal_tot, KOKKOS_LAMBDA (int idx_fmk_internal) { \
       int i1, i2, i3, i4;                                             \
-      conv::unflatten_idx_left(idx_fmk_internal, dims_fmk_internal, i1, i2, i3, i4); \
+      conv::unflatten_idx<LayoutT>(idx_fmk_internal, dims_fmk_internal, i1, i2, i3, i4); \
       kernel;                                                           \
     });                                                               \
   }
@@ -576,7 +612,7 @@ template <typename KView>
 struct ToYakl
 {
   using scalar_t = typename KView::value_type;
-  static constexpr auto yakl_mem = std::is_same<typename KView::device_type, HostDevice>::value ? yakl::memHost : yakl::memDevice;
+  static constexpr auto yakl_mem = std::is_same_v<typename KView::device_type, HostDevice> ? yakl::memHost : yakl::memDevice;
   using type = FArray<scalar_t, KView::rank, yakl_mem>;
 };
 
@@ -666,17 +702,17 @@ typename KView::non_const_value_type minval(const KView& view)
 
 // Get sum of view
 template <typename KView>
-std::conditional_t<std::is_same<typename KView::non_const_value_type, bool>::value, int, typename KView::non_const_value_type>
+std::conditional_t<std::is_same_v<typename KView::non_const_value_type, bool>, int, typename KView::non_const_value_type>
 sum(const KView& view)
 {
   using scalar_t    = typename KView::non_const_value_type;
   using exe_space_t = typename KView::execution_space;
-  using sum_t       = std::conditional_t<std::is_same<scalar_t, bool>::value, int, scalar_t>;
+  using sum_t       = std::conditional_t<std::is_same_v<scalar_t, bool>, int, scalar_t>;
 
   // If comparing sums of ints against f90, the values will need to be adjusted if
   // the sums are going to match. This would only be done during debugging, so disable
   // this for now.
-  // auto adjust = std::is_same<scalar_t, int>::value ? 1 : 0;
+  // auto adjust = std::is_same_v<scalar_t, int> ? 1 : 0;
 
   sum_t rv;
   Kokkos::parallel_reduce(
@@ -1243,8 +1279,8 @@ public:
     using myStyle = typename View::array_layout;
     using myMem   = typename View::memory_space;
     using T       = typename View::non_const_value_type;
-    constexpr bool is_c_layout   = std::is_same<myStyle, Kokkos::LayoutRight>::value;
-    constexpr bool is_device_mem = !std::is_same<myMem, Kokkos::DefaultHostExecutionSpace::memory_space>::value;
+    constexpr bool is_c_layout   = std::is_same_v<myStyle, Kokkos::LayoutRight>;
+    constexpr bool is_device_mem = !std::is_same_v<myMem, Kokkos::DefaultHostExecutionSpace::memory_space>;
     constexpr auto rank = View::rank;
 
     if (rank != dimNames.size()) { throw std::runtime_error("dimNames.size() != Array's rank"); }
@@ -1328,8 +1364,8 @@ public:
     using myStyle = typename View::array_layout;
     using myMem   = typename View::memory_space;
     using T       = typename View::non_const_value_type;
-    constexpr bool is_c_layout = std::is_same<myStyle, Kokkos::LayoutRight>::value;
-    constexpr bool is_device_mem = !std::is_same<myMem, Kokkos::DefaultHostExecutionSpace::memory_space>::value;
+    constexpr bool is_c_layout = std::is_same_v<myStyle, Kokkos::LayoutRight>;
+    constexpr bool is_device_mem = !std::is_same_v<myMem, Kokkos::DefaultHostExecutionSpace::memory_space>;
     constexpr auto rank = View::rank;
 
     if (rank != dimNames.size()) { throw std::runtime_error("dimNames.size() != Array's rank"); }
@@ -1433,7 +1469,7 @@ public:
     }
     LeftHostView read_data("read_data", llayout);
 
-    if (std::is_same<T,bool>::value) {
+    if (std::is_same_v<T,bool>) {
       int* tmp = new int[arr.size()];
       var.getVar(tmp);
       for (size_t i=0; i < arr.size(); ++i) { read_data.data()[i] = (tmp[i] == 1); }
@@ -1442,7 +1478,7 @@ public:
     else {
       var.getVar(read_data.data());
       // integer data is nearly always idx data, so adjust it to 0-based
-      if (std::is_same<T,int>::value) {
+      if (std::is_same_v<T,int>) {
         for (size_t i=0; i < arr.size(); ++i) { read_data.data()[i] -= 1; }
       }
     }
@@ -1476,19 +1512,19 @@ public:
 
   /** @private */
   template <class T> int getType() const {
-    if ( std::is_same<typename std::remove_cv<T>::type,signed        char>::value ) { return NC_BYTE;   }
-    else if ( std::is_same<typename std::remove_cv<T>::type,unsigned      char>::value ) { return NC_UBYTE;  }
-    else if ( std::is_same<typename std::remove_cv<T>::type,             short>::value ) { return NC_SHORT;  }
-    else if ( std::is_same<typename std::remove_cv<T>::type,unsigned     short>::value ) { return NC_USHORT; }
-    else if ( std::is_same<typename std::remove_cv<T>::type,               int>::value ) { return NC_INT;    }
-    else if ( std::is_same<typename std::remove_cv<T>::type,unsigned       int>::value ) { return NC_UINT;   }
-    else if ( std::is_same<typename std::remove_cv<T>::type,              long>::value ) { return NC_INT;    }
-    else if ( std::is_same<typename std::remove_cv<T>::type,unsigned      long>::value ) { return NC_UINT;   }
-    else if ( std::is_same<typename std::remove_cv<T>::type,         long long>::value ) { return NC_INT64;  }
-    else if ( std::is_same<typename std::remove_cv<T>::type,unsigned long long>::value ) { return NC_UINT64; }
-    else if ( std::is_same<typename std::remove_cv<T>::type,             float>::value ) { return NC_FLOAT;  }
-    else if ( std::is_same<typename std::remove_cv<T>::type,            double>::value ) { return NC_DOUBLE; }
-    if ( std::is_same<typename std::remove_cv<T>::type,              char>::value ) { return NC_CHAR;   }
+    if ( std::is_same_v<typename std::remove_cv<T>::type,signed        char> ) { return NC_BYTE;   }
+    else if ( std::is_same_v<typename std::remove_cv<T>::type,unsigned      char> ) { return NC_UBYTE;  }
+    else if ( std::is_same_v<typename std::remove_cv<T>::type,             short> ) { return NC_SHORT;  }
+    else if ( std::is_same_v<typename std::remove_cv<T>::type,unsigned     short> ) { return NC_USHORT; }
+    else if ( std::is_same_v<typename std::remove_cv<T>::type,               int> ) { return NC_INT;    }
+    else if ( std::is_same_v<typename std::remove_cv<T>::type,unsigned       int> ) { return NC_UINT;   }
+    else if ( std::is_same_v<typename std::remove_cv<T>::type,              long> ) { return NC_INT;    }
+    else if ( std::is_same_v<typename std::remove_cv<T>::type,unsigned      long> ) { return NC_UINT;   }
+    else if ( std::is_same_v<typename std::remove_cv<T>::type,         long long> ) { return NC_INT64;  }
+    else if ( std::is_same_v<typename std::remove_cv<T>::type,unsigned long long> ) { return NC_UINT64; }
+    else if ( std::is_same_v<typename std::remove_cv<T>::type,             float> ) { return NC_FLOAT;  }
+    else if ( std::is_same_v<typename std::remove_cv<T>::type,            double> ) { return NC_DOUBLE; }
+    if ( std::is_same_v<typename std::remove_cv<T>::type,              char> ) { return NC_CHAR;   }
     else { throw std::runtime_error("Invalid type"); }
     return -1;
   }

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -501,6 +501,8 @@ void unflatten_idx(const int idx, const Kokkos::Array<int, 4>& dims, int& i, int
   }
 }
 
+// The FLATTEN* macros expect LayoutT to be defined.
+
 #define FLATTEN_MD_KERNEL2(n1, n2, i1, i2, kernel)     \
   {                                                     \
     Kokkos::Array<int, 2> dims_fmk_internal = {n1, n2};         \

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -21,17 +21,21 @@
 
 #ifdef RRTMGP_ENABLE_KOKKOS
 #define GENERIC_INLINE KOKKOS_INLINE_FUNCTION
+#define KERNEL_FENCE Kokkos::fence()
 #else
 #define GENERIC_INLINE YAKL_INLINE
+#define KERNEL_FENCE yakl::fence()
 #endif
 
-//#define ENABLE_TIMING
+#define ENABLE_TIMING
 // Macro for timing kernels
 #ifdef ENABLE_TIMING
 #define TIMED_KERNEL(kernel)                                            \
 {                                                                       \
+  KERNEL_FENCE;                                                         \
   auto start_t = std::chrono::high_resolution_clock::now();             \
   kernel;                                                               \
+  KERNEL_FENCE;                                                         \
   auto stop_t = std::chrono::high_resolution_clock::now();              \
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop_t - start_t); \
   static double total_s = 0.;                                           \

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -465,6 +465,40 @@ void unflatten_idx_right(const int idx, const Kokkos::Array<int, 4>& dims, int& 
   l = idx % dims[3];
 }
 
+#define FLATTEN_MD_KERNEL2(n1, n2, i1, i2, kernel)     \
+  {                                                     \
+    Kokkos::Array<int, 2> dims_fmk_internal = {n1, n2};         \
+    const int dims_fmk_internal_tot = (n1)*(n2);                        \
+    Kokkos::parallel_for(dims_fmk_internal_tot, KOKKOS_LAMBDA (int idx_fmk_internal) { \
+      int i1, i2;                                                     \
+      conv::unflatten_idx_left(idx_fmk_internal, dims_fmk_internal, i1, i2); \
+      kernel;                                                           \
+    });                                                               \
+  }
+
+#define FLATTEN_MD_KERNEL3(n1, n2, n3, i1, i2, i3, kernel)       \
+  {                                                              \
+    Kokkos::Array<int, 3> dims_fmk_internal = {n1, n2, n3};      \
+    const int dims_fmk_internal_tot = (n1)*(n2)*(n3);                   \
+    Kokkos::parallel_for(dims_fmk_internal_tot, KOKKOS_LAMBDA (int idx_fmk_internal) { \
+      int i1, i2, i3;                                                 \
+      conv::unflatten_idx_left(idx_fmk_internal, dims_fmk_internal, i1, i2, i3); \
+      kernel;                                                           \
+    });                                                               \
+  }
+
+#define FLATTEN_MD_KERNEL4(n1, n2, n3, n4, i1, i2, i3, i4, kernel)       \
+  {                                                                     \
+    Kokkos::Array<int, 4> dims_fmk_internal = {n1, n2, n3, n4};         \
+    const int dims_fmk_internal_tot = (n1)*(n2)*(n3)*(n4);              \
+    Kokkos::parallel_for(dims_fmk_internal_tot, KOKKOS_LAMBDA (int idx_fmk_internal) { \
+      int i1, i2, i3, i4;                                             \
+      conv::unflatten_idx_left(idx_fmk_internal, dims_fmk_internal, i1, i2, i3, i4); \
+      kernel;                                                           \
+    });                                                               \
+  }
+
+
 #ifdef RRTMGP_ENABLE_YAKL
 // Compare a yakl array to a kokkos view, checking they are functionally
 // identical (same rank, dims, and values).

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -61,7 +61,7 @@
   total_s##name += duration##name.count() / 1000000.0;                  \
   std::cout << "TIMING For func " << __func__ << " file " << __FILE__ << " line " << __LINE__ << " total " << total_s##name << " s" << std::endl
 #else
-#define TIMED_INLINE_KERNEL(kernel) kernel
+#define TIMED_INLINE_KERNEL(name, kernel) kernel
 #endif
 
 

--- a/cpp/rte/expand_and_transpose.h
+++ b/cpp/rte/expand_and_transpose.h
@@ -24,10 +24,10 @@ void expand_and_transpose(OpticalPropsK<RealT, LayoutT, DeviceT> const &ops,
   Kokkos::View<int**, LayoutT, DeviceT> limits = ops.get_band_lims_gpoint();
   // for (int iband=1; iband <= nband; iband++) {
   //   for (int icol=1; icol <= ncol; icol++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nband}) , KOKKOS_LAMBDA (int icol, int iband) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nband, icol, iband,
     for (int igpt=limits(0,iband); igpt <= limits(1,iband); igpt++) {
       arr_out(icol, igpt) = arr_in(iband,icol);
     }
-  }));
+  ));
 }
 #endif

--- a/cpp/rte/expand_and_transpose.h
+++ b/cpp/rte/expand_and_transpose.h
@@ -24,7 +24,7 @@ void expand_and_transpose(OpticalPropsK<RealT, LayoutT, DeviceT> const &ops,
   Kokkos::View<int**, LayoutT, DeviceT> limits = ops.get_band_lims_gpoint();
   // for (int iband=1; iband <= nband; iband++) {
   //   for (int icol=1; icol <= ncol; icol++) {
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nband,ncol}) , KOKKOS_LAMBDA (int iband, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nband}) , KOKKOS_LAMBDA (int icol, int iband) {
     for (int igpt=limits(0,iband); igpt <= limits(1,iband); igpt++) {
       arr_out(icol, igpt) = arr_in(iband,icol);
     }

--- a/cpp/rte/kernels/mo_fluxes_broadband_kernels.h
+++ b/cpp/rte/kernels/mo_fluxes_broadband_kernels.h
@@ -25,7 +25,7 @@ void sum_broadband(int ncol, int nlev, int ngpt, SpectralT const &spectral_flux,
 
   // do ilev = 1, nlev
   //   do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlev}) , KOKKOS_LAMBDA (int icol, int ilev) {
     RealT bb_flux_s = 0.0;
     for (int igpt=0; igpt<ngpt; igpt++) {
       bb_flux_s += spectral_flux(icol, ilev, igpt);
@@ -44,7 +44,7 @@ void net_broadband(int ncol, int nlev, int ngpt, SpectralDnT const &spectral_flu
 
   // do ilev = 1, nlev
   //   do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlev}) , KOKKOS_LAMBDA (int icol, int ilev) {
     RealT diff = spectral_flux_dn(icol, ilev, 0) - spectral_flux_up(icol, ilev, 0);
     broadband_flux_net(icol, ilev) = diff;
   }));
@@ -52,7 +52,7 @@ void net_broadband(int ncol, int nlev, int ngpt, SpectralDnT const &spectral_flu
   // do igpt = 2, ngpt
   //   do ilev = 1, nlev
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlev}) , KOKKOS_LAMBDA (int icol, int ilev) {
     for (int igpt=1; igpt<ngpt; igpt++) {
       RealT diff = spectral_flux_dn(icol, ilev, igpt) - spectral_flux_up(icol, ilev, igpt);
       broadband_flux_net(icol,ilev) += diff;
@@ -73,7 +73,7 @@ void net_broadband(int ncol, int nlev, FluxDnT const &flux_dn, FluxUpT const &fl
 
   // do ilev = 1, nlev
   //   do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({nlev,ncol}) , KOKKOS_LAMBDA (int ilev, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlev}) , KOKKOS_LAMBDA (int icol, int ilev) {
      broadband_flux_net(icol,ilev) = flux_dn(icol,ilev) - flux_up(icol,ilev);
   }));
 }

--- a/cpp/rte/kernels/mo_fluxes_broadband_kernels.h
+++ b/cpp/rte/kernels/mo_fluxes_broadband_kernels.h
@@ -25,13 +25,13 @@ void sum_broadband(int ncol, int nlev, int ngpt, SpectralT const &spectral_flux,
 
   // do ilev = 1, nlev
   //   do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlev}) , KOKKOS_LAMBDA (int icol, int ilev) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlev, icol, ilev,
     RealT bb_flux_s = 0.0;
     for (int igpt=0; igpt<ngpt; igpt++) {
       bb_flux_s += spectral_flux(icol, ilev, igpt);
     }
     broadband_flux(icol, ilev) = bb_flux_s;
-  }));
+  ));
 }
 
 // Net flux: Spectral reduction over all points
@@ -44,20 +44,20 @@ void net_broadband(int ncol, int nlev, int ngpt, SpectralDnT const &spectral_flu
 
   // do ilev = 1, nlev
   //   do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlev}) , KOKKOS_LAMBDA (int icol, int ilev) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlev, icol, ilev,
     RealT diff = spectral_flux_dn(icol, ilev, 0) - spectral_flux_up(icol, ilev, 0);
     broadband_flux_net(icol, ilev) = diff;
-  }));
+  ));
 
   // do igpt = 2, ngpt
   //   do ilev = 1, nlev
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlev}) , KOKKOS_LAMBDA (int icol, int ilev) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlev, icol, ilev,
     for (int igpt=1; igpt<ngpt; igpt++) {
       RealT diff = spectral_flux_dn(icol, ilev, igpt) - spectral_flux_up(icol, ilev, igpt);
       broadband_flux_net(icol,ilev) += diff;
     }
-  }));
+  ));
 #ifdef RRTMGP_DEBUG
   std::cout << "WARNING: THIS ISN'T TESTED!\n";
   std::cout << __FILE__ << ": " << __LINE__ << std::endl;
@@ -73,8 +73,8 @@ void net_broadband(int ncol, int nlev, FluxDnT const &flux_dn, FluxUpT const &fl
 
   // do ilev = 1, nlev
   //   do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, nlev}) , KOKKOS_LAMBDA (int icol, int ilev) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL2(ncol, nlev, icol, ilev,
      broadband_flux_net(icol,ilev) = flux_dn(icol,ilev) - flux_up(icol,ilev);
-  }));
+  ));
 }
 #endif

--- a/cpp/rte/kernels/mo_optical_props_kernels.h
+++ b/cpp/rte/kernels/mo_optical_props_kernels.h
@@ -204,7 +204,7 @@ void increment_1scalar_by_1scalar(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}), KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,ngpt}), KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
   }));
   //std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
@@ -245,7 +245,7 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, TauT const &tau, SsaT
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     if (tau(icol,ilay,igpt) > eps) {
       RealT f  = g  (icol,ilay,igpt) * g  (icol,ilay,igpt);
       RealT wf = ssa(icol,ilay,igpt) * f;

--- a/cpp/rte/kernels/mo_optical_props_kernels.h
+++ b/cpp/rte/kernels/mo_optical_props_kernels.h
@@ -222,7 +222,7 @@ void inc_1scalar_by_1scalar_bybnd(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1 , ngpt
   //   do ilay = 1 , nlay
   //     do icol = 1 , ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     for (int ibnd=0; ibnd<nbnd; ibnd++) {
       if (igpt >= gpt_lims(0,ibnd) && igpt <= gpt_lims(1,ibnd) ) {
         tau1(icol,ilay,igpt) += tau2(icol,ilay,ibnd);

--- a/cpp/rte/kernels/mo_optical_props_kernels.h
+++ b/cpp/rte/kernels/mo_optical_props_kernels.h
@@ -168,7 +168,12 @@ void inc_2stream_by_2stream_bybnd(int ncol, int nlay, int ngpt,
   // do igpt = 1 , ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<4>({ncol,nlay,ngpt,nbnd}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt, int ibnd) {
+  Kokkos::Array<int, 4> dims4 = {ncol,nlay,ngpt,nbnd};
+  const int dims4_tot = ncol*nlay*ngpt*nbnd;
+  //TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<4>({ncol,nlay,ngpt,nbnd}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt, int ibnd) {
+  TIMED_KERNEL(Kokkos::parallel_for( dims4_tot, KOKKOS_LAMBDA (int idx) {
+    int icol, ilay, igpt, ibnd;
+    conv::unflatten_idx_left(idx, dims4, icol, ilay, igpt, ibnd);
     if (igpt >= gpt_lims(0,ibnd) && igpt <= gpt_lims(1,ibnd) ) {
       // t=tau1 + tau2
       RealT tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd);

--- a/cpp/rte/kernels/mo_optical_props_kernels.h
+++ b/cpp/rte/kernels/mo_optical_props_kernels.h
@@ -168,7 +168,7 @@ void inc_2stream_by_2stream_bybnd(int ncol, int nlay, int ngpt,
   // do igpt = 1 , ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<4>({nbnd,ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int ibnd, int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<4>({ncol,nlay,ngpt,nbnd}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt, int ibnd) {
     if (igpt >= gpt_lims(0,ibnd) && igpt <= gpt_lims(1,ibnd) ) {
       // t=tau1 + tau2
       RealT tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd);
@@ -297,7 +297,7 @@ void increment_2stream_by_2stream(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     // t=tau1 + tau2
     RealT tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
     // w=(tau1*ssa1 + tau2*ssa2) / t

--- a/cpp/rte/kernels/mo_optical_props_kernels.h
+++ b/cpp/rte/kernels/mo_optical_props_kernels.h
@@ -276,7 +276,7 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, TauT const &tau, SsaT
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol, nlay, ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     if (tau(icol,ilay,igpt) > eps) {
       RealT wf = ssa(icol,ilay,igpt) * f(icol,ilay,igpt);
       tau(icol,ilay,igpt) = (1. - wf) * tau(icol,ilay,igpt);

--- a/cpp/rte/kernels/mo_optical_props_kernels.h
+++ b/cpp/rte/kernels/mo_optical_props_kernels.h
@@ -170,7 +170,6 @@ void inc_2stream_by_2stream_bybnd(int ncol, int nlay, int ngpt,
   //     do icol = 1, ncol
   Kokkos::Array<int, 4> dims4 = {ncol,nlay,ngpt,nbnd};
   const int dims4_tot = ncol*nlay*ngpt*nbnd;
-  //TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<4>({ncol,nlay,ngpt,nbnd}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt, int ibnd) {
   TIMED_KERNEL(Kokkos::parallel_for( dims4_tot, KOKKOS_LAMBDA (int idx) {
     int icol, ilay, igpt, ibnd;
     conv::unflatten_idx_left(idx, dims4, icol, ilay, igpt, ibnd);
@@ -209,7 +208,7 @@ void increment_1scalar_by_1scalar(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,ngpt}), KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,ngpt}), KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
   }));
   //std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
@@ -227,7 +226,7 @@ void inc_1scalar_by_1scalar_bybnd(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1 , ngpt
   //   do ilay = 1 , nlay
   //     do icol = 1 , ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     for (int ibnd=0; ibnd<nbnd; ibnd++) {
       if (igpt >= gpt_lims(0,ibnd) && igpt <= gpt_lims(1,ibnd) ) {
         tau1(icol,ilay,igpt) += tau2(icol,ilay,ibnd);
@@ -250,7 +249,7 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, TauT const &tau, SsaT
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     if (tau(icol,ilay,igpt) > eps) {
       RealT f  = g  (icol,ilay,igpt) * g  (icol,ilay,igpt);
       RealT wf = ssa(icol,ilay,igpt) * f;
@@ -302,7 +301,7 @@ void increment_2stream_by_2stream(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     // t=tau1 + tau2
     RealT tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
     // w=(tau1*ssa1 + tau2*ssa2) / t

--- a/cpp/rte/kernels/mo_optical_props_kernels.h
+++ b/cpp/rte/kernels/mo_optical_props_kernels.h
@@ -168,11 +168,7 @@ void inc_2stream_by_2stream_bybnd(int ncol, int nlay, int ngpt,
   // do igpt = 1 , ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  Kokkos::Array<int, 4> dims4 = {ncol,nlay,ngpt,nbnd};
-  const int dims4_tot = ncol*nlay*ngpt*nbnd;
-  TIMED_KERNEL(Kokkos::parallel_for( dims4_tot, KOKKOS_LAMBDA (int idx) {
-    int icol, ilay, igpt, ibnd;
-    conv::unflatten_idx_left(idx, dims4, icol, ilay, igpt, ibnd);
+  TIMED_KERNEL(FLATTEN_MD_KERNEL4(ncol,nlay,ngpt,nbnd, icol, ilay, igpt, ibnd,
     if (igpt >= gpt_lims(0,ibnd) && igpt <= gpt_lims(1,ibnd) ) {
       // t=tau1 + tau2
       RealT tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,ibnd);
@@ -184,7 +180,7 @@ void inc_2stream_by_2stream_bybnd(int ncol, int nlay, int ngpt,
       ssa1(icol,ilay,igpt) = tauscat12 / Kokkos::fmax(eps,tau12);
       tau1(icol,ilay,igpt) = tau12;
     }
-  }));
+  ));
 }
 
 // Addition of optical properties: the first set are incremented by the second set.
@@ -208,9 +204,9 @@ void increment_1scalar_by_1scalar(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,ngpt}), KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL3(ncol,nlay,ngpt, icol, ilay, igpt,
     tau1(icol,ilay,igpt) = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
-  }));
+  ));
   //std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -226,13 +222,13 @@ void inc_1scalar_by_1scalar_bybnd(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1 , ngpt
   //   do ilay = 1 , nlay
   //     do icol = 1 , ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL3(ncol,nlay,ngpt, icol, ilay, igpt,
     for (int ibnd=0; ibnd<nbnd; ibnd++) {
       if (igpt >= gpt_lims(0,ibnd) && igpt <= gpt_lims(1,ibnd) ) {
         tau1(icol,ilay,igpt) += tau2(icol,ilay,ibnd);
       }
     }
-  }));
+  ));
 }
 
 // Delta-scale
@@ -249,7 +245,7 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, TauT const &tau, SsaT
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL3(ncol,nlay,ngpt, icol, ilay, igpt,
     if (tau(icol,ilay,igpt) > eps) {
       RealT f  = g  (icol,ilay,igpt) * g  (icol,ilay,igpt);
       RealT wf = ssa(icol,ilay,igpt) * f;
@@ -257,7 +253,7 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, TauT const &tau, SsaT
       ssa(icol,ilay,igpt) = (ssa(icol,ilay,igpt) - wf) / (1.0 - wf);
       g  (icol,ilay,igpt) = (g  (icol,ilay,igpt) -  f) / (1.0 -  f);
     }
-  }));
+  ));
 }
 
 
@@ -276,14 +272,14 @@ void delta_scale_2str_kernel(int ncol, int nlay, int ngpt, TauT const &tau, SsaT
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol, nlay, ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL3(ncol, nlay, ngpt, icol, ilay, igpt,
     if (tau(icol,ilay,igpt) > eps) {
       RealT wf = ssa(icol,ilay,igpt) * f(icol,ilay,igpt);
       tau(icol,ilay,igpt) = (1. - wf) * tau(icol,ilay,igpt);
       ssa(icol,ilay,igpt) = (ssa(icol,ilay,igpt) - wf) /  (1.0 - wf);
       g  (icol,ilay,igpt) = (g  (icol,ilay,igpt) - f(icol,ilay,igpt)) / (1. - f(icol,ilay,igpt));
     }
-  }));
+  ));
   std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 
@@ -301,7 +297,7 @@ void increment_2stream_by_2stream(int ncol, int nlay, int ngpt, Tau1T const &tau
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(FLATTEN_MD_KERNEL3(ncol,nlay,ngpt, icol, ilay, igpt,
     // t=tau1 + tau2
     RealT tau12 = tau1(icol,ilay,igpt) + tau2(icol,ilay,igpt);
     // w=(tau1*ssa1 + tau2*ssa2) / t
@@ -312,7 +308,7 @@ void increment_2stream_by_2stream(int ncol, int nlay, int ngpt, Tau1T const &tau
                            / Kokkos::fmax(eps,tauscat12);
     ssa1(icol,ilay,igpt) = tauscat12 / Kokkos::fmax(eps,tau12);
     tau1(icol,ilay,igpt) = tau12;
-  }));
+  ));
   //std::cout << "WARNING: THIS ISN'T TESTED: " << __FILE__ << ": " << __LINE__ << "\n";
 }
 

--- a/cpp/rte/kernels/mo_rte_solver_kernels.h
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.h
@@ -894,7 +894,7 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, DT const &D, 
 
   // do igpt = 1, ngpt
   //   do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
     // Transport is for intensity
     //   convert flux at top of domain to intensity assuming azimuthal isotropy
     radn_dn(icol,top_level,igpt) = radn_dn(icol,top_level,igpt)/(2. * pi * weights(weight_ind));
@@ -909,7 +909,6 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, DT const &D, 
   //     do icol = 1, ncol
   Kokkos::Array<int, 3> dims3_ngpt_nlay_ncol = {ncol,nlay,ngpt};
   const int dims3_ngpt_nlay_ncol_tot = ngpt * nlay * ncol;
-  //TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay,ncol}) , KOKKOS_LAMBDA (int igpt, int ilay, int icol) {
   TIMED_KERNEL(Kokkos::parallel_for( dims3_ngpt_nlay_ncol_tot , KOKKOS_LAMBDA (int idx) {
     int icol, ilay, igpt;
     conv::unflatten_idx_left(idx, dims3_ngpt_nlay_ncol, icol, ilay, igpt);
@@ -968,7 +967,7 @@ void lw_solver_noscat_GaussQuad(int ncol, int nlay, int ngpt, bool top_at_1, int
 
   // do igpt = 1, ngpt
   //   do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
     Ds_ncol(icol, igpt) = Ds(0);
   }));
 
@@ -982,7 +981,7 @@ void lw_solver_noscat_GaussQuad(int ncol, int nlay, int ngpt, bool top_at_1, int
 
   // do igpt = 1, ngpt
   //   do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
     flux_top(icol,igpt) = flux_dn(icol,top_level,igpt);
   }));
 
@@ -991,7 +990,7 @@ void lw_solver_noscat_GaussQuad(int ncol, int nlay, int ngpt, bool top_at_1, int
   for (int imu=1; imu<nmus; imu++) {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol, ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       Ds_ncol(icol, igpt) = Ds(imu);
     }));
 
@@ -1003,7 +1002,7 @@ void lw_solver_noscat_GaussQuad(int ncol, int nlay, int ngpt, bool top_at_1, int
     // do igpt = 1, ngpt
     //   do ilev = 1, nlay+1
     //     do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ngpt,nlay+1,ncol}) , KOKKOS_LAMBDA (int igpt, int ilev, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol, nlay+1, ngpt}) , KOKKOS_LAMBDA (int icol, int ilev, int igpt) {
       flux_up(icol,ilev,ngpt) += radn_up(icol,ilev,ngpt);
       flux_dn(icol,ilev,ngpt) += radn_dn(icol,ilev,ngpt);
     }));

--- a/cpp/rte/kernels/mo_rte_solver_kernels.h
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.h
@@ -704,7 +704,6 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, AlbedoSfcT const &albed
     TIMED_KERNEL(Kokkos::parallel_for( dims2_tot , KOKKOS_LAMBDA (int idx) {
       int icol, igpt;
       conv::unflatten_idx_left(idx, dims2_ncol_ngpt, icol, igpt);
-    //TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<2>({ncol,ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       int ilev = nlay;
       // Albedo of lowest level is the surface albedo...
       albedo(icol,igpt,ilev)  = albedo_sfc(icol,igpt);
@@ -831,7 +830,7 @@ void sw_solver_2stream(int ncol, int nlay, int ngpt, bool top_at_1, TauT const &
   // do igpt = 1, ngpt
   //   do ilay = 1, nlay+1
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay+1,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay+1,ngpt}) , KOKKOS_LAMBDA (int icol, int ilay, int igpt) {
     flux_dn(icol,ilay,igpt) = flux_dn(icol,ilay,igpt) + flux_dir(icol,ilay,igpt);
   }));
 
@@ -933,7 +932,7 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, DT const &D, 
   // do igpt = 1, ngpt
   //   do ilev = 1, nlay+1
   //     do icol = 1, ncol
-  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template getrl<3>({ncol,nlay+1,ngpt}) , KOKKOS_LAMBDA (int icol, int ilev, int igpt) {
+  TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<3>({ncol,nlay+1,ngpt}) , KOKKOS_LAMBDA (int icol, int ilev, int igpt) {
     radn_dn(icol,ilev,igpt) = 2. * pi * weights(weight_ind) * radn_dn(icol,ilev,igpt);
     radn_up(icol,ilev,igpt) = 2. * pi * weights(weight_ind) * radn_up(icol,ilev,igpt);
   }));

--- a/cpp/rte/kernels/mo_rte_solver_kernels.h
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.h
@@ -613,13 +613,13 @@ void apply_BC(int ncol, int nlay, int ngpt, bool top_at_1, FluxDnT const &flux_d
   if (top_at_1) {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       flux_dn(icol,      0, igpt)  = 0;
     }));
   } else {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       flux_dn(icol, nlay, igpt)  = 0;
     }));
   }
@@ -634,13 +634,13 @@ void apply_BC(int ncol, int nlay, int ngpt, bool top_at_1, IncFluxT const &inc_f
   if (top_at_1) {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       flux_dn(icol,      0, igpt)  = inc_flux(icol,igpt) * factor(icol);
     }));
   } else {
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       flux_dn(icol, nlay, igpt)  = inc_flux(icol,igpt) * factor(icol);
     }));
   }
@@ -659,14 +659,14 @@ void apply_BC(int ncol, int nlay, int ngpt, bool top_at_1, IncFluxT const &inc_f
     //$acc  parallel loop collapse(2)
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       flux_dn(icol,      0, igpt)  = inc_flux(icol,igpt);
     }));
   } else {
     //$acc  parallel loop collapse(2)
     // do igpt = 1, ngpt
     //   do icol = 1, ncol
-    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ngpt,ncol}) , KOKKOS_LAMBDA (int igpt, int icol) {
+    TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({ncol,ngpt}) , KOKKOS_LAMBDA (int icol, int igpt) {
       flux_dn(icol, nlay, igpt)  = inc_flux(icol,igpt);
     }));
   }

--- a/cpp/rte/kernels/mo_rte_solver_kernels.h
+++ b/cpp/rte/kernels/mo_rte_solver_kernels.h
@@ -513,7 +513,7 @@ inline void sw_two_stream(int ncol, int nlay, int ngpt, Mu0T const &mu0, TauT co
   using LayoutT = typename TauT::array_layout;
   using DeviceT = typename TauT::device_type;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
-  using pool = conv::MemPoolSingleton<RealT, DeviceT>;
+  using pool = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
 
   auto mu0_inv = pool::template alloc<RealT>(ncol);
 
@@ -672,7 +672,7 @@ void adding(int ncol, int nlay, int ngpt, bool top_at_1, AlbedoSfcT const &albed
   using LayoutT = typename TdifT::array_layout;
   using DeviceT = typename TdifT::device_type;
   using ureal3d_t = conv::Unmanaged<Kokkos::View<RealT***, LayoutT, DeviceT>>;
-  using pool    = conv::MemPoolSingleton<RealT, DeviceT>;
+  using pool    = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
   const int dsize1 = ncol*(nlay+1)*ngpt;
@@ -784,7 +784,7 @@ void sw_solver_2stream(int ncol, int nlay, int ngpt, bool top_at_1, TauT const &
   using RealT   = typename TauT::non_const_value_type;
   using LayoutT = typename TauT::array_layout;
   using DeviceT = typename TauT::device_type;
-  using pool = conv::MemPoolSingleton<RealT, DeviceT>;
+  using pool = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
   using ureal2d_t = conv::Unmanaged<Kokkos::View<RealT**, LayoutT, DeviceT>>;
@@ -840,7 +840,7 @@ void lw_solver_noscat(int ncol, int nlay, int ngpt, bool top_at_1, DT const &D, 
   using RealT   = typename TauT::non_const_value_type;
   using LayoutT = typename TauT::array_layout;
   using DeviceT = typename TauT::device_type;
-  using pool = conv::MemPoolSingleton<RealT, DeviceT>;
+  using pool = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
   using ureal2d_t = conv::Unmanaged<Kokkos::View<RealT**, LayoutT, DeviceT>>;
@@ -942,7 +942,7 @@ void lw_solver_noscat_GaussQuad(int ncol, int nlay, int ngpt, bool top_at_1, int
   using RealT   = typename TauT::non_const_value_type;
   using LayoutT = typename TauT::array_layout;
   using DeviceT = typename TauT::device_type;
-  using pool = conv::MemPoolSingleton<RealT, DeviceT>;
+  using pool = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
   using mdrp_t  = typename conv::MDRP<LayoutT, DeviceT>;
 
   using ureal2d_t = conv::Unmanaged<Kokkos::View<RealT**, LayoutT, DeviceT>>;

--- a/cpp/rte/mo_optical_props.h
+++ b/cpp/rte/mo_optical_props.h
@@ -387,13 +387,13 @@ public:
     //   for (int i = 1; i <= size(band_lims_wvn,1); i++) {
     auto this_band_lims_wvn = this->band_lims_wvn;
     if (this->is_initialized()) {
-      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(0) , band_lims_wvn.extent(1)}) , KOKKOS_LAMBDA (int i, int j) {
+      TIMED_KERNEL(FLATTEN_MD_KERNEL2(band_lims_wvn.extent(0) , band_lims_wvn.extent(1), i, j,
         ret(i,j) = 1. / this_band_lims_wvn(i,j);
-      }));
+      ));
     } else {
-      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(0) , band_lims_wvn.extent(1)}) , KOKKOS_LAMBDA (int i, int j) {
+      TIMED_KERNEL(FLATTEN_MD_KERNEL2(band_lims_wvn.extent(0) , band_lims_wvn.extent(1), i, j,
         ret(i,j) = 0.;
-      }));
+      ));
     }
     return ret;
   }
@@ -402,13 +402,13 @@ public:
   void get_band_lims_wavelength(WavelengthBounds const& ret) const {
     auto this_band_lims_wvn = this->band_lims_wvn;
     if (this->is_initialized()) {
-      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(1) , band_lims_wvn.extent(0)}) , KOKKOS_LAMBDA (int j, int i) {
+      TIMED_KERNEL(FLATTEN_MD_KERNEL2(band_lims_wvn.extent(1) , band_lims_wvn.extent(0), j, i,
         ret(i,j) = 1. / this_band_lims_wvn(i,j);
-      }));
+      ));
     } else {
-      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(1) , band_lims_wvn.extent(0)}) , KOKKOS_LAMBDA (int j, int i) {
+      TIMED_KERNEL(FLATTEN_MD_KERNEL2(band_lims_wvn.extent(1) , band_lims_wvn.extent(0), j, i,
         ret(i,j) = 0.;
-      }));
+      ));
     }
   }
 

--- a/cpp/rte/mo_optical_props.h
+++ b/cpp/rte/mo_optical_props.h
@@ -282,6 +282,9 @@ public:
     set_gpt2band(band_lims_gpt_lcl, this->gpt2band);
   }
 
+  // This function does the same thing as the one above, except takes Views as arguments
+  // instead of allocating new ones. Presumably, these views would come from the pool
+  // allocator in order to avoid cudaMalloc (hurts performance).
   template <typename BandLimsWvnT, typename Band2Gpt, typename Gpt2Band>
   void init_no_alloc( BandLimsWvnT const &band_lims_wvn ,
                       Band2Gpt const& band2gpt_mem,
@@ -308,8 +311,10 @@ public:
   }
 
   template <typename BandLimsWvnT, typename BandLimsGptT, typename Band2Gpt, typename Gpt2Band>
-  void init_no_alloc( BandLimsWvnT const &band_lims_wvn , BandLimsGptT const &band_lims_gpt,
-                      Band2Gpt const& band2gpt_mem, Gpt2Band const& gpt2band_mem,
+  void init_no_alloc( BandLimsWvnT const &band_lims_wvn,
+                      BandLimsGptT const &band_lims_gpt,
+                      Band2Gpt const& band2gpt_mem,
+                      Gpt2Band const& gpt2band_mem,
                       std::string name="" ) {
     if (band_lims_wvn.extent(0) != 2) { stoprun("optical_props::init(): band_lims_wvn 1st dim should be 2"); }
     #ifdef RRTMGP_EXPENSIVE_CHECKS

--- a/cpp/rte/mo_optical_props.h
+++ b/cpp/rte/mo_optical_props.h
@@ -373,11 +373,11 @@ public:
     //   for (int i = 1; i <= size(band_lims_wvn,1); i++) {
     auto this_band_lims_wvn = this->band_lims_wvn;
     if (this->is_initialized()) {
-      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(1) , band_lims_wvn.extent(0)}) , KOKKOS_LAMBDA (int j, int i) {
+      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(0) , band_lims_wvn.extent(1)}) , KOKKOS_LAMBDA (int i, int j) {
         ret(i,j) = 1. / this_band_lims_wvn(i,j);
       }));
     } else {
-      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(1) , band_lims_wvn.extent(0)}) , KOKKOS_LAMBDA (int j, int i) {
+      TIMED_KERNEL(Kokkos::parallel_for( mdrp_t::template get<2>({band_lims_wvn.extent(0) , band_lims_wvn.extent(1)}) , KOKKOS_LAMBDA (int i, int j) {
         ret(i,j) = 0.;
       }));
     }

--- a/cpp/rte/mo_optical_props.h
+++ b/cpp/rte/mo_optical_props.h
@@ -166,20 +166,6 @@ public:
     using yakl::fortran::parallel_for;
     using yakl::fortran::SimpleBounds;
 
-    // if ( this->get_nband() != rhs.get_nband() || this->get_nband() == 0) { return false; }
-    // yakl::ScalarLiveOut<bool> ret(true);
-    // // for (int j=1 ; j <= size(this->band_lims_wvn,2); j++) {
-    // //   for (int i=1 ; i <= size(this->band_lims_wvn,1); i++) {
-    // auto &this_band_lims_wvn = this->band_lims_wvn;
-    // auto &rhs_band_lims_wvn  = rhs.band_lims_wvn;
-    // TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<2>( size(this->band_lims_wvn,2) , size(this->band_lims_wvn,1) ) , YAKL_LAMBDA (int j, int i) {
-    //   if ( std::abs( this_band_lims_wvn(i,j) - rhs_band_lims_wvn(i,j) ) > 5*epsilon(this_band_lims_wvn) ) {
-    //     ret = false;
-    //   }
-    // }));
-    // return ret.hostRead();
-
-
     // This is working around an issue that arises in E3SM's rrtmgpxx integration.
     // Previously the code failed in the creation of the ScalarLiveOut variable, but only for higher optimizations
     bool ret = true;
@@ -204,15 +190,6 @@ public:
     using yakl::fortran::SimpleBounds;
 
     if ( ! this->bands_are_equal(rhs) || this->get_ngpt() != rhs.get_ngpt() ) { return false; }
-    // yakl::ScalarLiveOut<bool> ret(true);
-    // // for (int i=1; i <= size(this->gpt2bnd,1); i++) {
-    // auto &this_gpt2band = this->gpt2band;
-    // auto &rhs_gpt2band  = rhs.gpt2band;
-    // TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<1>(size(this->gpt2band,1)) , YAKL_LAMBDA (int i) {
-    //   if ( this_gpt2band(i) != rhs_gpt2band(i) ) { ret = false; }
-    // }));
-    // return ret.hostRead();
-
 
     // This is working around an issue that arises in E3SM's rrtmgpxx integration.
     // Previously the code failed in the creation of the ScalarLiveOut variable, but only for higher optimizations
@@ -224,25 +201,6 @@ public:
     }
     return ret;
   }
-
-
-  // Expand an array of dimension arr_in(nband) to dimension arr_out(ngpt)
-  // real1d expand(real1d const &arr_in) const {
-  //   real1d ret("arr_out",size(this->gpt2band,1));
-  //   // do iband=1,this->get_nband()
-  //   // TODO: I don't know if this needs to be serialize or not at first glance. Need to look at it more.
-  //   auto &this_band2gpt = this->gpt2band;
-  //   int nband = get_nband();
-  //   TIMED_KERNEL(parallel_for( YAKL_AUTO_LABEL() , Bounds<1>(1) , YAKL_LAMBDA (int dummy) {
-  //     for (int iband = 1 ; iband <= nband ; iband++) {
-  //       for (int i=this_band2gpt(1,iband) ; i <= this_band2gpt(2,iband) ; i++) {
-  //         ret(i) = arr_in(iband);
-  //       }
-  //     }
-  //   }));
-  //   return ret;
-  // }
-
 
   void set_name( std::string name ) { this->name = name; }
 

--- a/cpp/rte/mo_rte_lw.h
+++ b/cpp/rte/mo_rte_lw.h
@@ -152,7 +152,7 @@ void rte_lw(int max_gauss_pts, GaussDsT const &gauss_Ds, GaussWtsT const &gauss_
             bool top_at_1, SourceFuncLWK<RealT, LayoutT, DeviceT> const &sources, SfcEmisT const &sfc_emis,
             FluxesType &fluxes, IncFluxT const &inc_flux=IncFluxT(), int n_gauss_angles=-1)
 {
-  using pool = conv::MemPoolSingleton<RealT, DeviceT>;
+  using pool = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
   using ureal1d_t = conv::Unmanaged<Kokkos::View<RealT*,   LayoutT, DeviceT>>;
   using ureal2d_t = conv::Unmanaged<Kokkos::View<RealT**,  LayoutT, DeviceT>>;
   using ureal3d_t = conv::Unmanaged<Kokkos::View<RealT***, LayoutT, DeviceT>>;

--- a/cpp/rte/mo_rte_lw.h
+++ b/cpp/rte/mo_rte_lw.h
@@ -174,14 +174,11 @@ void rte_lw(int max_gauss_pts, GaussDsT const &gauss_Ds, GaussWtsT const &gauss_
     n_quad_angs = n_gauss_angles;
   }
 
-  const int dsize1 = ncol * (nlay+1) * ngpt;
-  const int dsize2 = ncol * ngpt;
-  RealT* data = pool::template alloc_raw<RealT>(dsize1*2 + dsize2 + 2*n_quad_angs), *dcurr = data;
-  ureal3d_t gpt_flux_up (dcurr,ncol,nlay+1,ngpt); dcurr += dsize1;
-  ureal3d_t gpt_flux_dn (dcurr,ncol,nlay+1,ngpt); dcurr += dsize1;
-  ureal2d_t sfc_emis_gpt(dcurr,ncol       ,ngpt); dcurr += dsize2;
-  ureal1d_t tmp_Ds      (dcurr,n_quad_angs); dcurr += n_quad_angs;
-  ureal1d_t tmp_wts     (dcurr,n_quad_angs); dcurr += n_quad_angs;
+  auto gpt_flux_up  = pool::template alloc<RealT>(ncol,nlay+1,ngpt);
+  auto gpt_flux_dn  = pool::template alloc<RealT>(ncol,nlay+1,ngpt);
+  auto sfc_emis_gpt = pool::template alloc<RealT>(ncol       ,ngpt);
+  auto tmp_Ds       = pool::template alloc<RealT>(n_quad_angs);
+  auto tmp_wts      = pool::template alloc<RealT>(n_quad_angs);
 
   // Error checking
   //   if inc_flux is present it has the right dimensions, is positive definite
@@ -236,6 +233,10 @@ void rte_lw(int max_gauss_pts, GaussDsT const &gauss_Ds, GaussWtsT const &gauss_
   // ...and reduce spectral fluxes to desired output quantities
   fluxes.reduce(gpt_flux_up, gpt_flux_dn, optical_props, top_at_1);
 
-  pool::dealloc(data, dcurr - data);
+  pool::dealloc(gpt_flux_up);
+  pool::dealloc(gpt_flux_dn);
+  pool::dealloc(sfc_emis_gpt);
+  pool::dealloc(tmp_Ds);
+  pool::dealloc(tmp_wts);
 }
 #endif

--- a/cpp/rte/mo_rte_sw.h
+++ b/cpp/rte/mo_rte_sw.h
@@ -140,14 +140,11 @@ void rte_sw(OpticalProps2strK<RealT, LayoutT, DeviceT> const &atmos, bool top_at
   const int ngpt  = atmos.get_ngpt();
   const int nband = atmos.get_nband();
 
-  const int dsize1 = ncol * (nlay+1) * ngpt;
-  const int dsize2 = ncol * ngpt;
-  RealT* data = pool::template alloc_raw<RealT>(dsize1*3 + dsize2*2), *dcurr = data;
-  ureal3d_t gpt_flux_up    (dcurr,ncol, nlay+1, ngpt); dcurr += dsize1;
-  ureal3d_t gpt_flux_dn    (dcurr,ncol, nlay+1, ngpt); dcurr += dsize1;
-  ureal3d_t gpt_flux_dir   (dcurr,ncol, nlay+1, ngpt); dcurr += dsize1;
-  ureal2d_t sfc_alb_dir_gpt(dcurr,ncol, ngpt);         dcurr += dsize2;
-  ureal2d_t sfc_alb_dif_gpt(dcurr,ncol, ngpt);         dcurr += dsize2;
+  auto gpt_flux_up     = pool::template alloc<RealT>(ncol, nlay+1, ngpt);
+  auto gpt_flux_dn     = pool::template alloc<RealT>(ncol, nlay+1, ngpt);
+  auto gpt_flux_dir    = pool::template alloc<RealT>(ncol, nlay+1, ngpt);
+  auto sfc_alb_dir_gpt = pool::template alloc<RealT>(ncol, ngpt);
+  auto sfc_alb_dif_gpt = pool::template alloc<RealT>(ncol, ngpt);
 
   // Error checking -- consistency of sizes and validity of values
   if (! fluxes.are_desired()) { stoprun("rte_sw: no space allocated for fluxes"); }
@@ -203,6 +200,10 @@ void rte_sw(OpticalProps2strK<RealT, LayoutT, DeviceT> const &atmos, bool top_at
   // ...and reduce spectral fluxes to desired output quantities
   fluxes.reduce(gpt_flux_up, gpt_flux_dn, atmos, top_at_1, gpt_flux_dir);
 
-  pool::dealloc(data, dcurr - data);
+  pool::dealloc(gpt_flux_up);
+  pool::dealloc(gpt_flux_dn);
+  pool::dealloc(gpt_flux_dir);
+  pool::dealloc(sfc_alb_dir_gpt);
+  pool::dealloc(sfc_alb_dif_gpt);
 }
 #endif

--- a/cpp/rte/mo_rte_sw.h
+++ b/cpp/rte/mo_rte_sw.h
@@ -131,7 +131,7 @@ void rte_sw(OpticalProps2strK<RealT, LayoutT, DeviceT> const &atmos, bool top_at
             SfcDirT const &sfc_alb_dir, SfcDifT const &sfc_alb_dif,
             FluxesType &fluxes, IncFluxDifT const &inc_flux_dif=IncFluxDifT())
 {
-  using pool = conv::MemPoolSingleton<RealT, DeviceT>;
+  using pool = conv::MemPoolSingleton<RealT, LayoutT, DeviceT>;
   using ureal2d_t = conv::Unmanaged<Kokkos::View<RealT**,  LayoutT, DeviceT>>;
   using ureal3d_t = conv::Unmanaged<Kokkos::View<RealT***, LayoutT, DeviceT>>;
 

--- a/cpp/rte/mo_source_functions.h
+++ b/cpp/rte/mo_source_functions.h
@@ -166,6 +166,9 @@ public:
     this->lev_source_dec = view_t<RealT***>("lev_source_dec",ncol,nlay,ngpt); // ALLOC
   }
 
+  // This function does the same thing as the one above, except takes Views as arguments
+  // instead of allocating new ones. Presumably, these views would come from the pool
+  // allocator in order to avoid cudaMalloc (hurts performance).
   template <typename SfcSourceMem, typename LaySourceMem, typename LevSourceIncMem, typename LevSourceDecMem>
   void alloc_no_alloc(int ncol, int nlay, SfcSourceMem const& sfc_source_mem, LaySourceMem const& lay_source_mem, LevSourceIncMem const& lev_source_inc_mem, LevSourceDecMem const& lev_source_dec_mem) {
     if (! this->is_initialized()) { stoprun("source_func_lw%alloc: not initialized so can't allocate"); }
@@ -183,6 +186,9 @@ public:
     this->alloc(ncol,nlay);
   }
 
+  // This function does the same thing as the one above, except takes Views as arguments
+  // instead of allocating new ones. Presumably, these views would come from the pool
+  // allocator in order to avoid cudaMalloc (hurts performance).
   template <typename Band2Gpt, typename Gpt2Band, typename SfcSourceMem, typename LaySourceMem, typename LevSourceIncMem, typename LevSourceDecMem>
   void alloc_no_alloc(int ncol, int nlay, parent_t const &op, Band2Gpt const& band2gpt_mem, Gpt2Band const& gpt2band_mem, SfcSourceMem const& sfc_source_mem, LaySourceMem const& lay_source_mem, LevSourceIncMem const& lev_source_inc_mem, LevSourceDecMem const& lev_source_dec_mem) {
     if (! op.is_initialized()) { stoprun("source_func_lw::alloc: op not initialized"); }

--- a/cpp/rte/mo_source_functions.h
+++ b/cpp/rte/mo_source_functions.h
@@ -170,7 +170,6 @@ public:
   void alloc_no_alloc(int ncol, int nlay, SfcSourceMem const& sfc_source_mem, LaySourceMem const& lay_source_mem, LevSourceIncMem const& lev_source_inc_mem, LevSourceDecMem const& lev_source_dec_mem) {
     if (! this->is_initialized()) { stoprun("source_func_lw%alloc: not initialized so can't allocate"); }
     if (ncol <= 0 || nlay <= 0) { stoprun("source_func_lw%alloc: must provide positive extents for ncol, nlay"); }
-    int ngpt = this->get_ngpt();
     this->sfc_source     = sfc_source_mem;
     this->lay_source     = lay_source_mem;
     this->lev_source_inc = lev_source_inc_mem;

--- a/cpp/rte/mo_source_functions.h
+++ b/cpp/rte/mo_source_functions.h
@@ -160,10 +160,21 @@ public:
     if (! this->is_initialized()) { stoprun("source_func_lw%alloc: not initialized so can't allocate"); }
     if (ncol <= 0 || nlay <= 0) { stoprun("source_func_lw%alloc: must provide positive extents for ncol, nlay"); }
     int ngpt = this->get_ngpt();
-    this->sfc_source     = view_t<RealT**> ("sfc_source"    ,ncol,ngpt);
-    this->lay_source     = view_t<RealT***>("lay_source"    ,ncol,nlay,ngpt);
-    this->lev_source_inc = view_t<RealT***>("lev_source_inc",ncol,nlay,ngpt);
-    this->lev_source_dec = view_t<RealT***>("lev_source_dec",ncol,nlay,ngpt);
+    this->sfc_source     = view_t<RealT**> ("sfc_source"    ,ncol,ngpt);      // ALLOC
+    this->lay_source     = view_t<RealT***>("lay_source"    ,ncol,nlay,ngpt); // ALLOC
+    this->lev_source_inc = view_t<RealT***>("lev_source_inc",ncol,nlay,ngpt); // ALLOC
+    this->lev_source_dec = view_t<RealT***>("lev_source_dec",ncol,nlay,ngpt); // ALLOC
+  }
+
+  template <typename SfcSourceMem, typename LaySourceMem, typename LevSourceIncMem, typename LevSourceDecMem>
+  void alloc_no_alloc(int ncol, int nlay, SfcSourceMem const& sfc_source_mem, LaySourceMem const& lay_source_mem, LevSourceIncMem const& lev_source_inc_mem, LevSourceDecMem const& lev_source_dec_mem) {
+    if (! this->is_initialized()) { stoprun("source_func_lw%alloc: not initialized so can't allocate"); }
+    if (ncol <= 0 || nlay <= 0) { stoprun("source_func_lw%alloc: must provide positive extents for ncol, nlay"); }
+    int ngpt = this->get_ngpt();
+    this->sfc_source     = sfc_source_mem;
+    this->lay_source     = lay_source_mem;
+    this->lev_source_inc = lev_source_inc_mem;
+    this->lev_source_dec = lev_source_dec_mem;
   }
 
   void alloc(int ncol, int nlay, parent_t const &op) {
@@ -171,6 +182,14 @@ public:
     this->finalize();
     this->init(op);
     this->alloc(ncol,nlay);
+  }
+
+  template <typename Band2Gpt, typename Gpt2Band, typename SfcSourceMem, typename LaySourceMem, typename LevSourceIncMem, typename LevSourceDecMem>
+  void alloc_no_alloc(int ncol, int nlay, parent_t const &op, Band2Gpt const& band2gpt_mem, Gpt2Band const& gpt2band_mem, SfcSourceMem const& sfc_source_mem, LaySourceMem const& lay_source_mem, LevSourceIncMem const& lev_source_inc_mem, LevSourceDecMem const& lev_source_dec_mem) {
+    if (! op.is_initialized()) { stoprun("source_func_lw::alloc: op not initialized"); }
+    this->finalize();
+    this->init_no_alloc(op.get_band_lims_wavenumber(), op.get_band_lims_gpoint(), band2gpt_mem, gpt2band_mem);
+    this->alloc_no_alloc(ncol, nlay, sfc_source_mem, lay_source_mem, lev_source_inc_mem, lev_source_dec_mem);
   }
 
   void finalize() {


### PR DESCRIPTION
Performance was measured with this case:
`SMS_Ln300.ne30pg2_ne30pg2.F2010-SCREAMv1.frontier-scream-gpu_crayclang-scream.scream-perf_test--scream-output-preset-1`

With these changes, we appear to be spending less time in kokkos kernels than yakl kernels:
```
Total time spent in YAKL kernels:   16.262377
Total time spent in Kokkos kernels: 14.596052
```

Change list:
* Replaces all multi-dimensional kernel launches with macro FLATTEN_MD_KERNEL$N. This removes most uses of Kokkos' MDRange policy, which does not seem to perform as well in most cases.
* YAKL SimpleBounds always has the right index being the fast one; it was inverting the dimensions to get layout left, ex:
```
parallel_for( YAKL_AUTO_LABEL() , SimpleBounds<3>(a,b,c) {
   md_array(c, b, a)
}
```
^ Notice the index order flip. FLATTEN_MD_KERNEL works for both left and right layouts and will do the right thing in either case, so there's no need to do this inversion..
* Get rid of all uses of alloc_raw to allocate multiple temporary views at the same time. This was leading to views that were not cache aligned which hurt performance.
* Adds non-allocating versions of some routines. YAKL didn't have to worry about this since it was doing pool allocations for all arrays automatically. The non-allocating routines take a view that has already been created (presumably via the pool allocator).
* Add fences to timing macros to ensure accurate times
* Tweaks to the pool allocator to improve performance. Round up all allocations to cache line size.
* Prefer `type_check_v<type>` over `type_check<type>::value`
