### PR TITLE
disable printing verbose warnings at end of runtime

### DIFF
--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -904,9 +904,9 @@ struct MemPoolSingleton
   }
 
   static inline
-  void finalize()
+  void finalize(bool verbose=true)
   {
-    print_state();
+    if (verbose) print_state;
     assert(s_curr_used == 0); // !=0 indicates we may have forgetten a dealloc
     s_mem = memview_t();
   }
@@ -914,10 +914,7 @@ struct MemPoolSingleton
   static inline
   void print_state()
   {
-    if (s_curr_used != 0) {
-      std::cout << "Warning: s_curr_used is not 0! Used " << s_curr_used << " out of " << s_mem.size() 
-                << ", high_water was " << s_high_water << std::endl;
-    }
+    std::cout << "rrtmgp_conversion MemPoolSingleton used " << s_curr_used << " out of " << s_mem.size() << "; high_water was " << s_high_water << std::endl;
   }
 };
 

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -906,8 +906,8 @@ struct MemPoolSingleton
   static inline
   void finalize(bool verbose=true)
   {
-    if (verbose) print_state;
-    assert(s_curr_used == 0); // !=0 indicates we may have forgetten a dealloc
+    if (verbose) print_state();
+    assert(s_curr_used == 0); // !=0 indicates we may have forgotten a dealloc
     s_mem = memview_t();
   }
 

--- a/cpp/rrtmgp_conversion.h
+++ b/cpp/rrtmgp_conversion.h
@@ -914,7 +914,10 @@ struct MemPoolSingleton
   static inline
   void print_state()
   {
-    std::cout << "Used " << s_curr_used << " of out of " << s_mem.size() << ", high_water was " << s_high_water << std::endl;
+    if (s_curr_used != 0) {
+      std::cout << "Warning: s_curr_used is not 0! Used " << s_curr_used << " out of " << s_mem.size() 
+                << ", high_water was " << s_high_water << std::endl;
+    }
   }
 };
 


### PR DESCRIPTION
disable printing verbose warnings at end of runtime

xref https://github.com/E3SM-Project/E3SM/issues/7115