### PR TITLE
Allow cmake to find netcdf natively or through client application

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,6 +3,11 @@
 ## It also assumes you've enabled CXX and C as languages
 ###############################################################################
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules)
+set(CMAKE_PREFIX_PATH ${NETCDF_DIR} ${CMAKE_PREFIX_PATH})
+
+find_package(NetCDF REQUIRED)
+
 # Add RRTMGP source files.
 set(CXX_SRC
   rrtmgp/kernels/mo_gas_optics_kernels.cpp
@@ -27,6 +32,9 @@ endif()
 if (RRTMGP_ENABLE_KOKKOS)
   target_link_libraries(rrtmgp Kokkos::kokkos)
 endif()
+
+target_include_directories(rrtmgp PUBLIC $<BUILD_INTERFACE:${NETCDF_INCLUDES}>)
+target_link_libraries(rrtmgp $<BUILD_INTERFACE:${NETCDF_LIBRARIES}>)
 
 # Special compile flags for C++ source
 target_include_directories(rrtmgp PUBLIC ./)

--- a/cpp/cmake-modules/FindNetCDF.cmake
+++ b/cpp/cmake-modules/FindNetCDF.cmake
@@ -1,0 +1,72 @@
+# - Find NetCDF
+# Find the native NetCDF includes and library
+#
+# NETCDF_INCLUDES    - where to find netcdf.h, etc
+# NETCDF_LIBRARIES   - Link these libraries when using NetCDF
+# NETCDF_FOUND       - True if NetCDF found including required interfaces (see below)
+#
+# Your package can require certain interfaces to be FOUND by setting these
+#
+# NETCDF_CXX         - require the C++ interface and link the C++ library
+# NETCDF_F77         - require the F77 interface and link the fortran library
+# NETCDF_F90         - require the F90 interface and link the fortran library
+#
+# The following are not for general use and are included in
+# NETCDF_LIBRARIES if the corresponding option above is set.
+#
+# NETCDF_LIBRARIES_C    - Just the C interface
+# NETCDF_LIBRARIES_CXX  - C++ interface, if available
+# NETCDF_LIBRARIES_F77  - Fortran 77 interface, if available
+# NETCDF_LIBRARIES_F90  - Fortran 90 interface, if available
+#
+# Normal usage would be:
+# set (NETCDF_F90 "YES")
+# find_package (NetCDF REQUIRED)
+# target_link_libraries (uses_f90_interface ${NETCDF_LIBRARIES})
+# target_link_libraries (only_uses_c_interface ${NETCDF_LIBRARIES_C})
+
+if(NETCDF_INCLUDES AND NETCDF_LIBRARIES)
+    # Already in cache, be silent
+    set(NETCDF_FIND_QUIETLY TRUE)
+endif(NETCDF_INCLUDES AND NETCDF_LIBRARIES)
+
+find_path(NETCDF_INCLUDES netcdf.h
+    HINTS NETCDF_DIR ENV NETCDF_DIR)
+
+find_library(NETCDF_LIBRARIES_C NAMES netcdf HINTS NETCDF_DIR/lib ENV NETCDF_DIR)
+mark_as_advanced(NETCDF_LIBRARIES_C)
+
+set(NetCDF_has_interfaces "YES") # will be set to NO if we're missing any interfaces
+set(NetCDF_libs "${NETCDF_LIBRARIES_C}")
+
+get_filename_component(NetCDF_lib_dirs "${NETCDF_LIBRARIES_C}" PATH)
+
+macro(NetCDF_check_interface lang header libs)
+    if(NETCDF_${lang})
+        find_path(NETCDF_INCLUDES_${lang} NAMES ${header}
+            HINTS "${NETCDF_INCLUDES}" NO_DEFAULT_PATH)
+        find_library(NETCDF_LIBRARIES_${lang} NAMES ${libs}
+            HINTS "${NetCDF_lib_dirs}" NO_DEFAULT_PATH)
+        mark_as_advanced(NETCDF_INCLUDES_${lang} NETCDF_LIBRARIES_${lang})
+
+        if(NETCDF_INCLUDES_${lang} AND NETCDF_LIBRARIES_${lang})
+            list(INSERT NetCDF_libs 0 ${NETCDF_LIBRARIES_${lang}}) # prepend so that -lnetcdf is last
+        else(NETCDF_INCLUDES_${lang} AND NETCDF_LIBRARIES_${lang})
+            set(NetCDF_has_interfaces "NO")
+            message(STATUS "Failed to find NetCDF interface for ${lang}")
+        endif(NETCDF_INCLUDES_${lang} AND NETCDF_LIBRARIES_${lang})
+    endif(NETCDF_${lang})
+endmacro(NetCDF_check_interface)
+
+NetCDF_check_interface(CXX netcdfcpp.h netcdf_c++)
+#NetCDF_check_interface(F77 netcdf.inc netcdff)
+#NetCDF_check_interface(F90 netcdf.mod netcdff)
+
+set(NETCDF_LIBRARIES "${NetCDF_libs}" CACHE STRING "All NetCDF libraries required for interface level")
+
+# handle the QUIETLY and REQUIRED arguments and set NETCDF_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(NetCDF DEFAULT_MSG NETCDF_LIBRARIES NETCDF_INCLUDES NetCDF_has_interfaces)
+
+mark_as_advanced(NETCDF_LIBRARIES NETCDF_INCLUDES)


### PR DESCRIPTION
@AMLattanzi

A bug fix for exposing netcdf to the cmake build system. Found this to be a solution when building ERF.